### PR TITLE
Add author of used note-ipfs deploy to trusted agents 

### DIFF
--- a/packages/utils/api/createProfile.ts
+++ b/packages/utils/api/createProfile.ts
@@ -1,4 +1,4 @@
-import { AD4M_AGENT, KAICHAO_AGENT, JUNTO_AGENT } from "utils/constants/agents";
+import { AD4M_AGENT, KAICHAO_AGENT, JUNTO_AGENT, NOTE_IPFS_AUTHOR } from "utils/constants/agents";
 import { NOTE_IPFS_EXPRESSION_OFFICIAL } from "utils/constants/languages";
 import {
   FLUX_PROFILE,
@@ -53,6 +53,7 @@ export default async ({
       AD4M_AGENT,
       KAICHAO_AGENT,
       JUNTO_AGENT,
+      NOTE_IPFS_AUTHOR,
     ]);
     await client.languages.byAddress(NOTE_IPFS_EXPRESSION_OFFICIAL);
 

--- a/packages/utils/constants/agents.ts
+++ b/packages/utils/constants/agents.ts
@@ -6,3 +6,6 @@ export const AD4M_AGENT =
 
 export const KAICHAO_AGENT =
   "did:key:zQ3shfhvaHzE81hZqLorVNDmq971EpGPXq3nhyLF1JRP18LM3";
+
+export const NOTE_IPFS_AUTHOR = 
+  "did:key:zQ3shmm1adTSjzyVqWthFkJ4yby8zCdH5uvwxWaQDEuJLUPfq";


### PR DESCRIPTION
This fixes the `Language not created by trusted agent` error when signing up for now, but actually I would suggest to remove all of these trusted agents and rely on 
1. the (currently broken) exception pop-up, so the user gets notified that he starts trusting a new agent (... and ultimately don't even request a capability that can just add trusted agents..)
2. using languages that come with the bootstrap seed