### PR TITLE
Fix semver plugin check.

### DIFF
--- a/app/src/containers/CreateChannel.vue
+++ b/app/src/containers/CreateChannel.vue
@@ -145,9 +145,14 @@ export default defineComponent({
       const res = await getAllFluxApps();
 
       this.isLoading = false;
-      const filtered = res.filter((pkg) =>
-        semver.gte(pkg?.ad4mVersion || "0.0.0", "0.8.1")
-      );
+
+      const filtered = res.filter((pkg) => {
+        try {
+          return semver.gte(semver.coerce(pkg?.ad4mVersion || "0.0.0"), "0.8.1")
+        } catch (error) {
+          return false
+        }
+      });
 
       this.packages = filtered;
     } catch (error) {

--- a/app/src/containers/EditChannel.vue
+++ b/app/src/containers/EditChannel.vue
@@ -132,10 +132,19 @@ export default defineComponent({
     this.isLoading = true;
     const res = await getAllFluxApps();
     this.isLoading = false;
-    const filtered = res.filter((pkg) =>
-        semver.gte(pkg.ad4mVersion || "0.0.0", dependencies["@coasys/ad4m"])
-      );
-      this.packages = filtered
+
+    const filtered = res.filter((pkg) => {
+      try {
+        return semver.gte(
+          semver.coerce(pkg.ad4mVersion || "0.0.0"),
+          semver.coerce(dependencies["@coasys/ad4m"])
+        )
+      } catch (error) {
+        return false
+      }
+    });
+
+    this.packages = filtered
   },
   async setup(props) {
     const route = useRoute();


### PR DESCRIPTION
This PR fixes the semver check on plugins.

Currently, if someone creates a plugin with an invalid semantic version of @coasys/ad4m or a version with pre-release info (e.g. the latest version: `0.10.0-rc7.local-ai.4`) it breaks community plugins for everyone.