### PR TITLE
Synergy processing updates

### DIFF
--- a/app/src/store/app/index.ts
+++ b/app/src/store/app/index.ts
@@ -49,6 +49,10 @@ export const useAppStore = defineStore("app", {
       notification: {
         globalNotification: false,
       },
+      activeWebrtc: {
+        instance: undefined,
+        channelId: "",
+      }
     };
   },
   getters,

--- a/app/src/store/app/mutations/index.ts
+++ b/app/src/store/app/mutations/index.ts
@@ -1,9 +1,4 @@
-import {
-  UpdateState,
-  ToastState,
-  ThemeState,
-  CurrentThemeState,
-} from "@/store/types";
+import { UpdateState, ToastState, ThemeState, CurrentThemeState } from "@/store/types";
 import { useAppStore } from "..";
 
 export default {
@@ -122,5 +117,10 @@ export default {
   setGlobalNotification(payload: boolean): void {
     const state = useAppStore();
     state.notification.globalNotification = payload;
+  },
+  setActiveWebrtc(instance: any, channelId: string): void {
+    const state = useAppStore();
+    state.activeWebrtc.instance = instance;
+    state.activeWebrtc.channelId = channelId;
   },
 };

--- a/app/src/store/types/state.ts
+++ b/app/src/store/types/state.ts
@@ -31,4 +31,8 @@ export interface ApplicationState {
   notification: {
     globalNotification: boolean;
   };
+  activeWebrtc: {
+    instance: any;
+    channelId: string;
+  };
 }

--- a/app/src/views/channel/ChannelView.vue
+++ b/app/src/views/channel/ChannelView.vue
@@ -110,6 +110,7 @@
         :source="channelId"
         :agent="agentClient"
         :perspective="data.perspective"
+        :appStore="appStore"
         :currentView="currentView"
         :setModalOpen="() => (webrtcModalOpen = false)"
         @click="onViewClick"

--- a/packages/api/src/channel/index.ts
+++ b/packages/api/src/channel/index.ts
@@ -71,9 +71,10 @@ export class Channel extends SubjectEntity {
             instance(TaskClass, ItemId), 
             property_getter(TaskClass, ItemId, "name", Text)
           )
-        ), Items).
+        ), Items),
+        sort(Items, SortedItems).
       `);
-      return (result[0]?.Items || []).map(([itemId, author, timestamp, type, text]) => ({
+      return (result[0]?.SortedItems || []).map(([itemId, author, timestamp, type, text]) => ({
         baseExpression: itemId,
         author,
         timestamp: new Date(timestamp).toISOString(),

--- a/packages/api/src/channel/index.ts
+++ b/packages/api/src/channel/index.ts
@@ -72,15 +72,18 @@ export class Channel extends SubjectEntity {
             property_getter(TaskClass, ItemId, "name", Text)
           )
         ), Items),
-        sort(Items, SortedItems).
+        % 5. Remove duplicates
+        sort(Items, UniqueItems).
       `);
-      return (result[0]?.SortedItems || []).map(([itemId, author, timestamp, type, text]) => ({
-        baseExpression: itemId,
-        author,
-        timestamp: new Date(timestamp).toISOString(),
-        text: Literal.fromUrl(text).get().data,
-        icon: icons[type] ? icons[type] : "question",
-      }));
+      return (result[0]?.UniqueItems || [])
+        .map(([itemId, author, timestamp, type, text]) => ({
+          baseExpression: itemId,
+          author,
+          timestamp: new Date(timestamp).toISOString(),
+          text: Literal.fromUrl(text).get().data,
+          icon: icons[type] ? icons[type] : "question",
+        }))
+        .sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
     } catch (error) {
       console.error("Error getting channel items:", error);
       return [];

--- a/packages/api/src/conversation/index.ts
+++ b/packages/api/src/conversation/index.ts
@@ -130,7 +130,7 @@ export default class Conversation extends SubjectEntity {
       
           % 2. Retrieve subgroup properties
           property_getter(CS, Subgroup, "subgroupName", SubgroupName),
-          property_getter(CS, Subgroup, "summary", Summary),
+          (property_getter(CS, Subgroup, "summary", S) -> Summary = S ; Summary = ""),
       
           % 3. Collect timestamps for valid items only
           findall(Timestamp, (
@@ -172,7 +172,8 @@ export default class Conversation extends SubjectEntity {
       return (result[0]?.Subgroups || []).map(([baseExpression, subgroupName, summary, start, end]) => ({
         baseExpression,
         name: Literal.fromUrl(subgroupName).get().data,
-        summary: Literal.fromUrl(summary).get().data,
+        // handle the empty array that's returned if no summary is present
+        summary: Array.isArray(summary) ? "" : Literal.fromUrl(summary).get().data,
         start: parseInt(start, 10),
         end: parseInt(end, 10),
       }));

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -17,6 +17,7 @@
     "@coasys/flux-constants": "0.10.1-rc3",
     "@coasys/flux-types": "0.10.1-rc3",
     "json5": "^2.2.3",
+    "lodash": "^4.17.21",
     "openai": "^4.55.5"
   },
   "peerDependencies": {

--- a/packages/utils/src/synergy.ts
+++ b/packages/utils/src/synergy.ts
@@ -94,7 +94,7 @@ async function isMe(did: string): Promise<boolean> {
 
 export async function addSynergySignalHandler(
   perspective: PerspectiveProxy,
-  setProcessingData: (data: ProcessingData | null) => void,
+  setProcessingData: React.Dispatch<React.SetStateAction<ProcessingData | null>>,
   waitingToSeeIfOthersAreProcessing: React.MutableRefObject<boolean>
 ): Promise<void> {
   const neighbourhood = await perspective.getNeighbourhoodProxy();

--- a/packages/webrtc/src/WebRTCManager.ts
+++ b/packages/webrtc/src/WebRTCManager.ts
@@ -159,7 +159,7 @@ export class WebRTCManager {
     const that = this;
 
     this.connections.set = function (key: string, value: Connection) {
-      console.log(`✅ Added key: ${key} value: ${value} to the map`);
+      // console.log(`✅ Added key: ${key} value: ${value} to the map`);
 
       that.callbacks[Event.PEER_ADDED].forEach((cb) => {
         cb(key, value);
@@ -170,7 +170,7 @@ export class WebRTCManager {
 
     // Listen for deletions from the map
     this.connections.delete = function (key: string) {
-      console.log(`🚫 Deleted key: ${key} from the map`);
+      // console.log(`🚫 Deleted key: ${key} from the map`);
 
       that.callbacks[Event.PEER_REMOVED].forEach((cb) => {
         cb(key);
@@ -191,15 +191,15 @@ export class WebRTCManager {
     if (!this.isListening) return;
 
     if (expression.author === this.agent.did) {
-      console.log("Received signal from self, ignoring!");
+      // console.log("Received signal from self, ignoring!");
       return null;
     }
 
     const link = await getLinkFromPerspective(expression);
-    console.log(`🔵 ${link?.data?.predicate}`, {
-      link,
-      author: expression.author,
-    });
+    // console.log(`🔵 ${link?.data?.predicate}`, {
+    //   link,
+    //   author: expression.author,
+    // });
 
     if (!link) {
       this.addToEventLog(
@@ -273,11 +273,11 @@ export class WebRTCManager {
       return this.connections.get(remoteDid);
     }
 
-    console.log(
-      "🟠 Creating ",
-      initiator ? "active" : "passive",
-      " connection"
-    );
+    // console.log(
+    //   "🟠 Creating ",
+    //   initiator ? "active" : "passive",
+    //   " connection"
+    // );
 
     const ad4mPeer = new AD4MPeer({
       did: remoteDid,
@@ -372,9 +372,9 @@ export class WebRTCManager {
       if (!recepients || recepients.includes(key)) {
         try {
           e.peer.send(data);
-          console.log(`📩 Sending message to ${key} -> `, type);
+          // console.log(`📩 Sending message to ${key} -> `, type);
         } catch (e) {
-          console.log(`📩 Couldn't send message to ${key} -> `, type, e);
+          // console.log(`📩 Couldn't send message to ${key} -> `, type, e);
         }
       }
     });
@@ -419,7 +419,7 @@ export class WebRTCManager {
 
     const connection = this.connections.get(did);
     if (!connection) {
-      console.log("🔴 Failed to add log entry, no connection found!");
+      // console.log("🔴 Failed to add log entry, no connection found!");
       return;
     }
 
@@ -430,7 +430,7 @@ export class WebRTCManager {
    * Join the chat room, listen for signals
    */
   async join(initialSettings?: Settings) {
-    console.log("trying to join");
+    // console.log("trying to join");
 
     let settings = { audio: true, video: false, ...initialSettings };
 
@@ -489,7 +489,7 @@ export class WebRTCManager {
   }
 
   async heartbeat() {
-    console.log("💚 Sending HEARTBEAT");
+    // console.log("💚 Sending HEARTBEAT");
     this.addToEventLog(this.agent.did, HEARTBEAT);
 
     this.neighbourhood.sendBroadcastU({
@@ -504,7 +504,7 @@ export class WebRTCManager {
   }
 
   async sendTestSignal(recipientDid: string) {
-    console.log("⚙️ Sending TEST_SIGNAL to ", recipientDid);
+    // console.log("⚙️ Sending TEST_SIGNAL to ", recipientDid);
     this.neighbourhood.sendBroadcastU({
       links: [
         {
@@ -517,7 +517,7 @@ export class WebRTCManager {
   }
 
   async sendTestBroadcast() {
-    console.log("⚙️ Sending TEST_BROADCAST to room");
+    // console.log("⚙️ Sending TEST_BROADCAST to room");
     this.neighbourhood.sendBroadcastU({
       links: [
         {
@@ -530,7 +530,7 @@ export class WebRTCManager {
   }
 
   setIceServers(iceServers: IceServer[]) {
-    console.log("⚙️ Setting ICE servers: ", iceServers);
+    // console.log("⚙️ Setting ICE servers: ", iceServers);
     this.iceServers = iceServers;
   }
 }

--- a/views/synergy-demo-view/src/App.tsx
+++ b/views/synergy-demo-view/src/App.tsx
@@ -8,9 +8,10 @@ type Props = {
   agent: AgentClient;
   perspective: PerspectiveProxy;
   source: string;
+  appStore: any;
 };
 
-export default function App({ agent, perspective, source }: Props) {
+export default function App({ agent, perspective, source, appStore }: Props) {
   if (!perspective?.uuid || !agent) return "No perspective or agent client";
   return (
     <div className={styles.appContainer}>
@@ -18,7 +19,8 @@ export default function App({ agent, perspective, source }: Props) {
         agent={agent}
         perspective={perspective}
         source={source}
-      ></SynergyDemoView>
+        appStore={appStore}
+      />
     </div>
   );
 }

--- a/views/synergy-demo-view/src/components/SynergyDemoView/SynergyDemoView.tsx
+++ b/views/synergy-demo-view/src/components/SynergyDemoView/SynergyDemoView.tsx
@@ -9,9 +9,9 @@ import TimelineColumn from "../TimelineColumn";
 import styles from "./SynergyDemoView.module.scss";
 import { SynergyMatch, SynergyTopic, SearchType, FilterSettings } from "@coasys/flux-utils";
 
-type Props = { perspective: any; source: string; agent: AgentClient };
+type Props = { perspective: any; source: string; agent: AgentClient; appStore: any };
 
-export default function SynergyDemoView({ perspective, agent, source }: Props) {
+export default function SynergyDemoView({ perspective, agent, source, appStore }: Props) {
   const [matches, setMatches] = useState<SynergyMatch[]>([]);
   const [allTopics, setAllTopics] = useState<SynergyTopic[]>([]);
   const [selectedTopic, setSelectedTopic] = useState<SynergyTopic | null>(null);
@@ -154,6 +154,7 @@ export default function SynergyDemoView({ perspective, agent, source }: Props) {
             perspective={perspective}
             source={source}
             agent={agent}
+            appStore={appStore}
             currentView="@coasys/flux-synergy-demo-view"
           />
         </div>

--- a/views/synergy-demo-view/src/components/TimelineColumn/TimelineColumn.tsx
+++ b/views/synergy-demo-view/src/components/TimelineColumn/TimelineColumn.tsx
@@ -79,7 +79,8 @@ export default function TimelineColumn({ agent, perspective, channelId, selected
       gettingData.current = false;
       // after fetching new data, run processing check if unprocessed items still present
       const enoughUnprocessedItems = newUnproccessedItems.length >= minItemsToProcess + numberOfItemsDelay;
-      if (enoughUnprocessedItems) runProcessingCheck(perspective, channelId, newUnproccessedItems, setProcessingData);
+      if (enoughUnprocessedItems && !waitingToSeeIfOthersAreProcessing.current)
+        runProcessingCheck(perspective, channelId, newUnproccessedItems, setProcessingData);
     }
   }
 

--- a/views/synergy-demo-view/src/main.ts
+++ b/views/synergy-demo-view/src/main.ts
@@ -4,7 +4,7 @@ import MyComponent from "./App";
 
 const CustomElement = toCustomElement(
   MyComponent,
-  ["perspective", "agent", "source"],
+  ["perspective", "agent", "source", "appStore"],
   { shadow: false }
 );
 

--- a/views/webrtc-view/src/App.tsx
+++ b/views/webrtc-view/src/App.tsx
@@ -7,11 +7,12 @@ type Props = {
   source: string;
   perspective: PerspectiveProxy;
   agent: AgentClient;
+  appStore: any;
   currentView: string;
   setModalOpen?: (state: boolean) => void;
 };
 
-export default function App({ perspective, source, agent, currentView, setModalOpen }: Props) {
+export default function App({ perspective, source, agent, appStore, currentView, setModalOpen }: Props) {
   if (!perspective?.uuid || !source) {
     return null;
   }
@@ -22,6 +23,7 @@ export default function App({ perspective, source, agent, currentView, setModalO
         source={source}
         agent={agent}
         perspective={perspective}
+        appStore={appStore}
         currentView={currentView}
         setModalOpen={setModalOpen}
       />

--- a/views/webrtc-view/src/components/Channel/Channel.tsx
+++ b/views/webrtc-view/src/components/Channel/Channel.tsx
@@ -2,28 +2,27 @@ import { useAgent } from "@coasys/ad4m-react-hooks";
 import { useWebRTC } from "@coasys/flux-react-web";
 import { useContext, useEffect, useRef, useState } from "preact/hooks";
 import useIntersectionObserver from "../../hooks/useIntersectionObserver";
-
 import UiContext from "../../context/UiContext";
 import Footer from "../Footer";
 import JoinScreen from "../JoinScreen";
 import Notifications from "../Notifications";
 import Overlay from "../Overlay/Overlay";
 import UserGrid from "../UserGrid";
-
 import { Agent, PerspectiveProxy } from "@coasys/ad4m";
 import { AgentClient } from "@coasys/ad4m/lib/src/agent/AgentClient";
-
 // @ts-ignore
 import { Profile } from "@coasys/flux-types";
 import { profileFormatter } from "@coasys/flux-utils";
 import Debug from "../Debug";
 import Transcriber from "../Transcriber";
 import styles from "./Channel.module.scss";
+import { version } from "../../../../../app/package.json";
 
 type Props = {
   source: string;
   perspective: PerspectiveProxy;
   agent: AgentClient;
+  appStore: any;
   currentView: string;
   setModalOpen?: (state: boolean) => void;
 };
@@ -32,10 +31,12 @@ export default function Channel({
   source,
   perspective,
   agent: agentClient,
+  appStore,
   currentView,
   setModalOpen,
 }: Props) {
   const [agent, setAgent] = useState<Agent | null>(null);
+  const [inAnotherRoom, setInAnotherRoom] = useState(false);
   const wrapperEl = useRef<HTMLDivElement | null>(null);
 
   const { profile } = useAgent<Profile>({
@@ -70,6 +71,54 @@ export default function Channel({
     },
   });
 
+  function joinRoom(e) {
+    appStore.setActiveWebrtc(webRTC, source);
+    appStore.activeWebrtc.instance.onJoin(e);
+  }
+
+  function leaveRoom() {
+    if (appStore.activeWebrtc.instance) appStore.activeWebrtc.instance.onLeave();
+    appStore.setActiveWebrtc(undefined, '');
+    setInAnotherRoom(false);
+  }
+
+  useEffect(() => {
+
+    const cleanupWebRTC = () => {
+      try {
+        // 1. Cleanup WebRTC instance
+        if (appStore?.activeWebrtc?.instance) {
+          appStore.activeWebrtc.instance.onLeave();
+        }
+        // 2. Update store directly
+        const key = `app-${version}`;
+        const stored = localStorage.getItem(key);
+        if (stored) {
+          const state = JSON.parse(stored);
+          state.activeWebrtc = { instance: undefined, channelId: '' };
+          localStorage.setItem(key, JSON.stringify(state));
+        }
+        // 3. Update Pinia store
+        appStore.setActiveWebrtc(undefined, '');
+      } catch (error) {
+        console.error('WebRTC cleanup failed:', error);
+      }
+    };
+  
+    window.addEventListener('beforeunload', cleanupWebRTC, { capture: true });
+  
+    return () => {
+      window.removeEventListener('beforeunload', cleanupWebRTC);
+    };
+  }, [appStore]);
+
+  useEffect(() => {
+    if (appStore && appStore.activeWebrtc) {
+      const { channelId } = appStore.activeWebrtc;
+      setInAnotherRoom(!!channelId && channelId !== source);
+    }
+  }, [appStore, appStore?.activeWebrtc?.channelId]);
+
   // Get agent/me
   useEffect(() => {
     async function fetchAgent() {
@@ -93,13 +142,16 @@ export default function Channel({
             <j-icon name="x" color="color-white" />
           </button>
         )}
-      {!webRTC.hasJoined && (
+      {!webRTC.hasJoined && appStore && (
         <JoinScreen
           webRTC={webRTC}
           profile={profile}
           did={agent?.did}
           onToggleSettings={() => toggleShowSettings(!showSettings)}
           currentView={currentView}
+          inAnotherRoom={inAnotherRoom}
+          joinRoom={joinRoom}
+          leaveRoom={leaveRoom}
         />
       )}
 

--- a/views/webrtc-view/src/components/JoinScreen/JoinScreen.tsx
+++ b/views/webrtc-view/src/components/JoinScreen/JoinScreen.tsx
@@ -1,7 +1,6 @@
 import { WebRTC } from "@coasys/flux-react-web";
 import { Profile } from "@coasys/flux-types";
 import { useEffect, useRef } from "preact/hooks";
-
 import Avatar from "../Avatar";
 import Disclaimer from "../Disclaimer";
 import styles from "./JoinScreen.module.scss";
@@ -12,6 +11,9 @@ type Props = {
   onToggleSettings: () => void;
   did?: string;
   currentView: string;
+  inAnotherRoom?: boolean;
+  joinRoom?: () => void;
+  leaveRoom?: () => void;
 };
 
 export default function JoinScreen({
@@ -20,6 +22,9 @@ export default function JoinScreen({
   onToggleSettings,
   did,
   currentView,
+  inAnotherRoom,
+  joinRoom,
+  leaveRoom
 }: Props) {
   const videoRef = useRef(null);
 
@@ -112,15 +117,28 @@ export default function JoinScreen({
       </j-box>
 
       <j-box pt="500">
-        <j-button
-          variant="primary"
-          size="lg"
-          loading={webRTC.isLoading}
-          disabled={!webRTC.audioPermissionGranted}
-          onClick={webRTC.onJoin}
-        >
-          Join room!
-        </j-button>
+        {inAnotherRoom  ? (
+          <j-flex direction="column" gap="300" a="center">
+            <j-text>You're currently in another call! You'll need to leave that one before joining here.</j-text>
+            <j-button
+              variant="primary"
+              size="lg"
+              onClick={leaveRoom}
+            >
+              Leave other call
+            </j-button>
+          </j-flex>
+        ) : (
+          <j-button
+            variant="primary"
+            size="lg"
+            loading={webRTC.isLoading}
+            disabled={!webRTC.audioPermissionGranted}
+            onClick={joinRoom}
+          >
+            Join room!
+          </j-button>
+        )}
       </j-box>
 
       {currentView === "@coasys/flux-webrtc-view" && (

--- a/views/webrtc-view/src/main.ts
+++ b/views/webrtc-view/src/main.ts
@@ -6,7 +6,7 @@ import MyComponent from "./App";
 
 const CustomElement = toCustomElement(
   MyComponent,
-  ["perspective", "agent", "source", "currentView", "setModalOpen"],
+  ["perspective", "agent", "source", "currentView", "setModalOpen", "appStore"],
   { shadow: false }
 );
 


### PR DESCRIPTION
Miscellaneous remaining tasks and fixes related to the Synergy view:

- [X] Rerun processing check if enough unprocessed items still present after previous processing task complete
- [X] Signal other agents to check if processing in progress when mounting & update state accordingly
- [X] Store WebRTC state in app store so we can prevent users joining multiple calls at once
- [X] Re-send processing check signal every 5 seconds in-case the connection with the processing peer is lost