### PR TITLE
Similarity search with embedding vector language

### DIFF
--- a/packages/api/src/conversation/util.ts
+++ b/packages/api/src/conversation/util.ts
@@ -1,8 +1,8 @@
 import { AIClient } from "@coasys/ad4m";
 import Embedding from "../embedding";
 import SemanticRelationship from "../semantic-relationship";
-import { languages } from "@coasys/flux-constants";
-const { EMBEDDING_VECTOR_LANGUAGE } = languages;
+// import { languages } from "@coasys/flux-constants";
+// const { EMBEDDING_VECTOR_LANGUAGE } = languages;
 
 async function findEmbeddingSRId(perspective, itemId): Promise<string | null> {
   const result = await perspective.infer(`
@@ -49,9 +49,10 @@ export async function createEmbedding(perspective, text, itemId, ai: AIClient, b
   const start2 = new Date().getTime();
   const embedding = new Embedding(perspective, undefined, itemId);
   embedding.model = "bert";
-  const embeddingExpression = await perspective.createExpression(rawEmbedding, EMBEDDING_VECTOR_LANGUAGE);
-  console.log(`embeddingExpression for item ${index}:`, embeddingExpression);
-  embedding.embedding = embeddingExpression;
+
+  // const embeddingExpression = await perspective.createExpression(rawEmbedding, EMBEDDING_VECTOR_LANGUAGE);
+  console.log(`embeddingExpression for item ${index}:`, rawEmbedding);
+  embedding.embedding = rawEmbedding;
   await embedding.save(batchId);
   const end2 = new Date().getTime();
   console.log(`${index ? `Item ${index} e` : "E"}mbedding saved in ${duration(start2, end2)}`);

--- a/packages/api/src/embedding/index.ts
+++ b/packages/api/src/embedding/index.ts
@@ -14,13 +14,12 @@ export default class Embedding extends Ad4mModel {
 
   @Property({
     through: "flux://embedding",
-    writable: true,
+    resolveLanguage: EMBEDDING_VECTOR_LANGUAGE,
   })
   embedding: any;
 
   @Property({
     through: "flux://model",
-    writable: true,
     resolveLanguage: "literal",
   })
   model: string;

--- a/packages/api/src/semantic-relationship/index.ts
+++ b/packages/api/src/semantic-relationship/index.ts
@@ -58,7 +58,12 @@ export default class SemanticRelationship extends Ad4mModel {
         ${SEMANTIC_RELATIONSHIP_FOR_ITEM.replace("ItemId", `"${itemId}"`)}
         ${EMBEDDING_FROM_SEMANTIC_RELATIONSHIP}.
       `);
-      return result[0]?.Embedding ? JSON.parse(result[0].Embedding) : [];
+
+      if (!result?.[0]?.Embedding) return []
+      else {
+        const embeddingExpression = await this.perspective.getExpression(result[0].Embedding);
+        return JSON.parse(embeddingExpression.data);
+      };
     } catch (error) {
       console.error("Error getting items embedding", error);
       return [];
@@ -80,12 +85,15 @@ export default class SemanticRelationship extends Ad4mModel {
         ), Embeddings).
       `);
 
-      return (result[0]?.Embeddings || []).map(([baseExpression, embedding, channelId, channelName]) => ({
-        baseExpression,
-        type: "Conversation",
-        embedding: JSON.parse(embedding),
-        channelId,
-        channelName: Literal.fromUrl(channelName).get().data,
+      return Promise.all((result[0]?.Embeddings || []).map(async ([baseExpression, embedding, channelId, channelName]) => {
+        const embeddingExpression = await this.perspective.getExpression(embedding);
+        return {
+          baseExpression,
+          type: "Conversation",
+          embedding: JSON.parse(embeddingExpression.data),
+          channelId,
+          channelName: Literal.fromUrl(channelName).get().data,
+        }
       }));
     } catch (error) {
       console.error("Error getting all conversation embedding", error);
@@ -113,13 +121,16 @@ export default class SemanticRelationship extends Ad4mModel {
         ), Embeddings).
       `);
 
-      return (result[0]?.Embeddings || []).map(([baseExpression, embedding, channelId, channelName]) => ({
-        baseExpression,
-        type: "Subgroup",
-        embedding: JSON.parse(embedding),
-        channelId,
-        channelName: Literal.fromUrl(channelName).get().data,
-      }));
+      return Promise.all((result[0]?.Embeddings || []).map(async ([baseExpression, embedding, channelId, channelName]) => {
+        const embeddingExpression = await this.perspective.getExpression(embedding);
+        return {
+          baseExpression,
+          type: "Subgroup",
+          embedding: JSON.parse(embeddingExpression.data),
+          channelId,
+          channelName: Literal.fromUrl(channelName).get().data,
+        }
+      }))
     } catch (error) {
       console.error("Error getting all conversation embedding", error);
       return [];
@@ -152,12 +163,15 @@ export default class SemanticRelationship extends Ad4mModel {
         ), Embeddings).
       `);
 
-      return (result[0]?.Embeddings || []).map(([baseExpression, type, embedding, channelId, channelName]) => ({
-        baseExpression,
-        type,
-        embedding: JSON.parse(embedding),
-        channelId,
-        channelName: Literal.fromUrl(channelName).get().data,
+      return Promise.all((result[0]?.Embeddings || []).map(async ([baseExpression, type, embedding, channelId, channelName]) => {
+        const embeddingExpression = await this.perspective.getExpression(embedding);
+        return {
+          baseExpression,
+          type,
+          embedding: JSON.parse(embeddingExpression.data),
+          channelId,
+          channelName: Literal.fromUrl(channelName).get().data,
+        }
       }));
     } catch (error) {
       console.error("Error getting all conversation embedding", error);
@@ -180,12 +194,15 @@ export default class SemanticRelationship extends Ad4mModel {
         ), Embeddings).
       `);
 
-      return (result[0]?.Embeddings || []).map(([baseExpression, embedding, channelId, channelName]) => ({
-        baseExpression,
-        type: itemType,
-        embedding: JSON.parse(embedding),
-        channelId,
-        channelName: Literal.fromUrl(channelName).get().data,
+      return Promise.all((result[0]?.Embeddings || []).map(async ([baseExpression, embedding, channelId, channelName]) => {
+        const embeddingExpression = await this.perspective.getExpression(embedding);
+        return {
+          baseExpression,
+          type: itemType,
+          embedding: JSON.parse(embeddingExpression.data),
+          channelId,
+          channelName: Literal.fromUrl(channelName).get().data,
+        }
       }));
     } catch (error) {
       console.error("Error getting all conversation embedding", error);


### PR DESCRIPTION
First commit uses getExpression to resolve vector embeddings in the SemanticRelationship model methods (**tested and working**).

Second commit attempts to set the vector embedding resolveLanguage in the Embedding model definition (**fails when saving new embeddings: "Error processing items into conversation: ApolloError: No matching subject class found! "**)