### PR TITLE
Members fixes when changing perspective

### DIFF
--- a/app/src/views/community/community-sidebar/CommunitySidebar.vue
+++ b/app/src/views/community/community-sidebar/CommunitySidebar.vue
@@ -1,6 +1,6 @@
 <template>
   <Header :community="community" :isSynced="isSynced"></Header>
-  <Members></Members>
+  <Members :perspective="perspective"></Members>
   <ChannelList :perspective="perspective" :community="community"></ChannelList>
 </template>
 


### PR DESCRIPTION
Fixes a few issues in the Members component in the CommunitySidebar when changing perspectives:

- Stale data skipped if perspective changed before members retrieved
- Loading state stored in Members component and passed down to AvatarGroup to prevent delay in loading state when changing perspectives
- Members identicons displayed immediately when DID's available and then updated when images have loaded to reduce initial load time

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a loading indicator to the avatar group display, showing a spinner while member data is being fetched.
- **Improvements**
  - Member avatars and counts are now hidden while loading, providing a clearer user experience.
  - Member list updates more responsively when switching perspectives in the community sidebar.
- **Bug Fixes**
  - Prevented outdated member lists from displaying when quickly switching perspectives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->