### PR TITLE
Fix kanban view

### DIFF
--- a/views/kanban-view/src/components/Board/Board.tsx
+++ b/views/kanban-view/src/components/Board/Board.tsx
@@ -2,8 +2,9 @@ import { Ad4mModel, PerspectiveProxy, Literal, makeRandomPrologAtom } from "@coa
 import { useModel } from "@coasys/ad4m-react-hooks";
 import { AgentClient } from "@coasys/ad4m/lib/src/agent/AgentClient";
 import { useEffect, useMemo } from "preact/hooks";
-import { useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { DragDropContext, Draggable, Droppable } from "react-beautiful-dnd";
+import { getProfile } from "@coasys/flux-api";
 import Card from "../Card";
 import CardDetails from "../CardDetails";
 import styles from "./Board.module.css";
@@ -26,13 +27,25 @@ type NamedOptions = Record<string, NamedOption[]>;
 
 export default function Board({ perspective, source, agent }: BoardProps) {
   const [showAddColumn, setShowAddColumn] = useState(false);
-  const [currentTaskId, setCurrentTaskId] = useState<string | null>(null);
+  const [currentTask, setCurrentTask] = useState<Ad4mModel | null>(null);
   const [columnName, setColumnName] = useState("");
   const [classes, setClasses] = useState([]);
   const [selectedClass, setSelectedClass] = useState("");
   const [selectedProperty, setSelectedProperty] = useState("");
   const [namedOptions, setNamedOptions] = useState<NamedOptions>({});
   const [tasks, setTasks] = useState([]);
+
+  const cachedProfiles = useRef({});
+
+  const getCachedProfile = useCallback(async (did: string) => {
+    if (cachedProfiles.current[did]) {
+      return cachedProfiles.current[did];
+    }
+    
+    const profile = await getProfile(did);
+    cachedProfiles.current[did] = profile;
+    return profile;
+  }, []);
 
   useEffect(() => {
     perspective.infer(`subject_class("Task", Atom)`).then((hasTask) => {
@@ -62,6 +75,7 @@ export default function Board({ perspective, source, agent }: BoardProps) {
   }, [classes.length]);
 
   useEffect(() => {
+    console.log("changed entries:", entries);
     setTasks(entries);
   }, [JSON.stringify(entries), perspective.uuid]);
 
@@ -211,9 +225,9 @@ export default function Board({ perspective, source, agent }: BoardProps) {
                                 >
                                   <Card
                                     perspective={perspective}
-                                    selectedClass={selectedClass}
-                                    onClick={() => setCurrentTaskId(task.baseExpression)}
-                                    id={task.baseExpression}
+                                    onClick={() => setCurrentTask(task)}
+                                    task={task}
+                                    getProfile={getCachedProfile}
                                   ></Card>
                                 </div>
                               )}
@@ -249,20 +263,20 @@ export default function Board({ perspective, source, agent }: BoardProps) {
           </DragDropContext>
         </div>
       </div>
-      {currentTaskId && (
+      {currentTask && (
         <j-modal
-          open={currentTaskId ? true : false}
+          open={currentTask ? true : false}
           onToggle={(e) =>
-            setCurrentTaskId(e.currentTarget.open ? currentTaskId : null)
+            setCurrentTask(e.currentTarget.open ? currentTask : null)
           }
         >
           <CardDetails
             agent={agent}
             perspective={perspective}
             channelId={source}
-            id={currentTaskId}
+            task={currentTask}
             selectedClass={selectedClass}
-            onDeleted={() => setCurrentTaskId(null)}
+            onDeleted={() => setCurrentTask(null)}
           />
         </j-modal>
       )}
@@ -295,7 +309,7 @@ export default function Board({ perspective, source, agent }: BoardProps) {
   );
 }
 
-function transformData(tasks: any[], property: string, options: NamedOption[]) {
+function transformData(tasks: Ad4mModel[], property: string, options: NamedOption[]) {
   const defaultColumns = options.reduce(
     (acc, opt) => {
       return {
@@ -316,29 +330,31 @@ function transformData(tasks: any[], property: string, options: NamedOption[]) {
     }
   );
 
-  return tasks.reduce(
-    (acc, task) => {
-      const status = property || "Unknown";
+  // Create a map of task IDs to their full Ad4mModel instances
+  const taskMap = tasks.reduce((acc, task) => {
+    acc[task.baseExpression] = task;
+    return acc;
+  }, {});
 
-      return {
-        ...acc,
-        tasks: {
-          ...acc.tasks,
-          [task.baseExpression]: {
-            baseExpression: task.baseExpression,
-            title: task.title || task.name || task.baseExpression,
-          },
-        },
-        columns: addTaskToColumn(acc.columns, task, property),
-        columnOrder: acc.columnOrder,
+  // Organize tasks into columns while preserving the full Ad4mModel instances
+  const columns = tasks.reduce((acc, task) => {
+    const columnId = task[property] || "unknown";
+    if (!acc[columnId]) {
+      acc[columnId] = {
+        id: columnId,
+        title: columnId,
+        taskIds: [],
       };
-    },
-    {
-      tasks: {},
-      columns: defaultColumns,
-      columnOrder: options.map((c) => c.value),
     }
-  );
+    acc[columnId].taskIds.push(task.baseExpression);
+    return acc;
+  }, defaultColumns);
+
+  return {
+    tasks: taskMap,  // This now contains the full Ad4mModel instances
+    columns,
+    columnOrder: options.map((c) => c.value),
+  };
 }
 
 async function getNamedOptions(perspective, className): Promise<NamedOptions> {

--- a/views/kanban-view/src/components/Board/Board.tsx
+++ b/views/kanban-view/src/components/Board/Board.tsx
@@ -155,9 +155,16 @@ export default function Board({ perspective, source, agent }: BoardProps) {
     const status = destination.droppableId;
 
     setTasks((oldTasks) => {
-      return oldTasks.map((t) =>
-        t.baseExpression === draggableId ? { ...t, [selectedProperty]: status } : t
+      const changedTask = oldTasks.find((t) => t.baseExpression === draggableId)
+      if (changedTask) { 
+        changedTask[selectedProperty] = status;
+        changedTask.update();
+      }
+
+      const newTasks = oldTasks.map((t) =>
+        t.baseExpression === draggableId ? changedTask : t
       );
+      return newTasks;
     });
 
     // update state

--- a/views/kanban-view/src/components/Card/Card.tsx
+++ b/views/kanban-view/src/components/Card/Card.tsx
@@ -24,7 +24,7 @@ export default function Card({
   const { entries } = useModel({
     perspective,
     model: selectedClass,
-    query: { source: id },
+    query: { where: { base: id } },
   });
 
   const { entries: comments } = useModel({

--- a/views/kanban-view/src/components/Card/Card.tsx
+++ b/views/kanban-view/src/components/Card/Card.tsx
@@ -1,59 +1,62 @@
 import { useEffect, useState } from "preact/hooks";
 import { useModel } from "@coasys/ad4m-react-hooks";
 import styles from "./Card.module.css";
-import { PerspectiveProxy } from "@coasys/ad4m";
+import { Ad4mModel, PerspectiveProxy } from "@coasys/ad4m";
 import { useAssociations } from "../../hooks/useAssociations";
 import { Profile } from "@coasys/flux-types";
-import { Message, getProfile } from "@coasys/flux-api";
+import { Message } from "@coasys/flux-api";
 
 type Props = {
-  id: string;
+  task: Ad4mModel
   onClick: () => void;
   perspective: PerspectiveProxy;
-  selectedClass: string;
+  getProfile: (did: string) => Promise<Profile>;
 };
 
 export default function Card({
-  id,
+  task,
   onClick,
-  selectedClass,
   perspective,
+  getProfile,
 }: Props) {
   const [assignedProfiles, setAssignedProfiles] = useState<Profile[]>([]);
-
-  const { entries } = useModel({
-    perspective,
-    model: selectedClass,
-    query: { where: { base: id } },
-  });
+  console.log("task", task);
 
   const { entries: comments } = useModel({
     perspective,
     model: Message,
-    query: { source: id },
+    query: { source: task.baseExpression },
   });
 
-  const { associations } = useAssociations({
-    source: id,
-    perspective,
-    predicate: "rdf://has_assignee",
-  });
+  console.log("comments", comments);
 
   async function fetchProfiles() {
+    // @ts-ignore
+    console.log("fetching profiles", task.assignees);
+    // @ts-ignore
+    if (!task.assignees) {
+      console.log("no assignees");
+      setAssignedProfiles([]);
+      return;
+    }
+
     const profiles = await Promise.all(
-      associations.map((l) => getProfile(l.data.target))
+      // @ts-ignore
+      task.assignees?.map((l) => getProfile(l))
     );
     setAssignedProfiles(profiles);
   }
 
   useEffect(() => {
     fetchProfiles();
-  }, [associations.length]);
+    // @ts-ignore
+  }, [task.assignees?.length]);
 
   return (
     <div className={styles.card} onClick={onClick}>
       <j-text size="500" color="ui-800" nomargin>
-        {entries[0]?.name || entries[0]?.title || "Unnamed"}
+        {/* @ts-ignore */}
+        {task?.name || task?.title || "<Unnamed>"}
       </j-text>
 
       <j-flex full a="center" j="between">

--- a/views/kanban-view/src/components/CardDetails/CardDetails.tsx
+++ b/views/kanban-view/src/components/CardDetails/CardDetails.tsx
@@ -9,7 +9,7 @@ import Entry from "../Entry";
 import styles from "./CardDetails.module.css";
 
 type Props = {
-  id: string;
+  task: Ad4mModel;
   perspective: PerspectiveProxy;
   channelId: string;
   selectedClass: string;
@@ -19,29 +19,12 @@ type Props = {
 
 export default function CardDetails({
   agent,
-  id,
+  task,
   selectedClass,
   onDeleted = () => {},
   perspective,
   channelId,
 }: Props) {
-
-  const { entries } = useModel({
-    perspective,
-    model: selectedClass,
-    query: { source: id },
-  });
-
-  const {
-    associations: assignees,
-    add: addAssignee,
-    remove: removeAssignee,
-  } = useAssociations({
-    perspective,
-    source: id,
-    predicate: "rdf://has_assignee",
-  });
-
   const [showAssign, setShowAssign] = useState(false);
   const [profiles, setProfiles] = useState<Profile[]>([]);
 
@@ -62,9 +45,7 @@ export default function CardDetails({
 
   async function onDelete() {
     try {
-      const model = await perspective.getSubjectProxy(entries[0]?.baseExpression, selectedClass) as any;
-      const entry = new model(perspective, entries[0]?.baseExpression, id);
-      entry.delete();
+      task.delete();
       onDeleted();
     } catch (e) {
       // Todo: error handling
@@ -74,14 +55,24 @@ export default function CardDetails({
 
   function toggleAssignee(val: boolean, did: string) {
     if (val) {
-      addAssignee(did);
+      // @ts-ignore
+      if (!task.assignees.includes(did)) {
+        // @ts-ignore
+        task.assignees.push(did);
+      }
+      // @ts-ignore
+      task.update();
     } else {
-      removeAssignee(did);
+      // @ts-ignore
+      task.assignees = task.assignees.filter((d) => d !== did);
+      // @ts-ignore
+      task.update();
     }
   }
 
   const assignedProfiles = profiles.filter((p) =>
-    assignees.some((l) => l.data.target === p.did)
+    // @ts-ignore
+    task.assignees.some((l) => l === p.did)
   );
 
   return (
@@ -89,7 +80,7 @@ export default function CardDetails({
       <div className={styles.cardMain}>
         <j-box pb="800">
           <Entry
-            id={id}
+            task={task}
             perspective={perspective}
             selectedClass={selectedClass}
             channelId={channelId}
@@ -107,7 +98,7 @@ export default function CardDetails({
         <comment-section
           className={styles.commentSection}
           perspective={perspective}
-          source={id}
+          source={task.baseExpression}
           agent={agent}
         ></comment-section>
       </div>

--- a/views/kanban-view/src/components/CardDetails/CardDetails.tsx
+++ b/views/kanban-view/src/components/CardDetails/CardDetails.tsx
@@ -14,6 +14,7 @@ type Props = {
   channelId: string;
   selectedClass: string;
   agent: AgentClient;
+  allProfiles: ()=>Promise<Profile[]>;
   onDeleted: () => void;
 };
 
@@ -24,17 +25,13 @@ export default function CardDetails({
   onDeleted = () => {},
   perspective,
   channelId,
+  allProfiles,
 }: Props) {
   const [showAssign, setShowAssign] = useState(false);
   const [profiles, setProfiles] = useState<Profile[]>([]);
 
   async function fetchProfiles() {
-    const n = await perspective.getNeighbourhoodProxy();
-    const dids = await n.otherAgents();
-    const me = await agent.me();
-    const allAgents = [me.did, ...dids];
-    const profiles = await Promise.all(allAgents.map((d) => getProfile(d)));
-    setProfiles(profiles);
+    setProfiles(await allProfiles());
   }
 
   useEffect(() => {
@@ -132,8 +129,8 @@ export default function CardDetails({
                     <j-menu-item key={profile.did}>
                       <j-checkbox
                         full
-                        checked={assignees.some(
-                          (l) => l.data.target === profile.did
+                        checked={task.assignees.some(
+                          (a) => a === profile.did
                         )}
                         onChange={(e) =>
                           toggleAssignee(e.target.checked, profile.did)

--- a/views/kanban-view/src/components/DisplayValue/DisplayValue.tsx
+++ b/views/kanban-view/src/components/DisplayValue/DisplayValue.tsx
@@ -28,6 +28,7 @@ export default function DisplayValue({
 }: Props) {
   const inputRef = useRef();
   const [isEditing, setIsEditing] = useState(false);
+  const [localValue, setLocalValue] = useState(value);
 
   useEffect(() => {
     if (isEditing && inputRef.current) {
@@ -35,19 +36,27 @@ export default function DisplayValue({
     }
   }, [isEditing]);
 
+  useEffect(() => {
+    setLocalValue(value);
+  }, [value]);
+
   function onKeyDown(e) {
     if (e.key === "Enter") {
       e.preventDefault();
       setIsEditing(false);
+      onUpdate(e.target.value);
+      setLocalValue(e.target.value);
     }
     if (e.key === "Escape") {
       e.stopPropagation();
       setIsEditing(false);
+      setLocalValue(value);
     }
   }
 
   function onBlur(e) {
     onUpdate(e.target.value);
+    setLocalValue(e.target.value);
     setIsEditing(false);
   }
 
@@ -56,12 +65,12 @@ export default function DisplayValue({
     setIsEditing(true);
   }
 
-  const isCollection = Array.isArray(value);
+  const isCollection = Array.isArray(localValue);
 
   if (isCollection) {
     return (
       <j-flex gap="200" wrap>
-        {value.map((v, index) => {
+        {localValue.map((v, index) => {
           return <DisplayValue onUrlClick={onUrlClick} value={v} />;
         })}
       </j-flex>
@@ -73,7 +82,7 @@ export default function DisplayValue({
       <div className={styles.selectWrapper}>
         <select
           className={styles.select}
-          value={value}
+          value={localValue}
           onChange={(e) => onUpdate(e.target.value)}
         >
           {options.map((option) => (
@@ -95,32 +104,32 @@ export default function DisplayValue({
         onClick={(e) => e.stopPropagation()}
         onBlur={onBlur}
         onKeyDown={onKeyDown}
-        value={value}
+        value={localValue}
       ></input>
     );
   }
 
-  if (typeof value === "string") {
-    if (value.startsWith("did:key")) {
-      return <Profile did={value}></Profile>;
+  if (typeof localValue === "string") {
+    if (localValue.startsWith("did:key")) {
+      return <Profile did={localValue}></Profile>;
     }
 
-    if (value.length > 1000)
+    if (localValue.length > 1000)
       return (
-        <img className={styles.img} src={`data:image/png;base64,${value}`} />
+        <img className={styles.img} src={`data:image/png;base64,${localValue}`} />
       );
-    if (isValidUrl(value)) {
-      if (value.startsWith("literal://")) {
+    if (isValidUrl(localValue)) {
+      if (localValue.startsWith("literal://")) {
         return (
           <a
             className={styles.entryUrl}
-            href={value}
+            href={localValue}
             onClick={(e) => {
               e.stopPropagation();
-              onUrlClick(value);
+              onUrlClick(localValue);
             }}
           >
-            {Literal.fromUrl(value).get()}
+            {Literal.fromUrl(localValue).get()}
           </a>
         );
       }
@@ -128,13 +137,13 @@ export default function DisplayValue({
       return (
         <a
           className={styles.entryUrl}
-          href={value}
+          href={localValue}
           onClick={(e) => {
             e.stopPropagation();
-            onUrlClick(value);
+            onUrlClick(localValue);
           }}
         >
-          {value}
+          {localValue}
         </a>
       );
     }
@@ -142,19 +151,19 @@ export default function DisplayValue({
     return (
       <j-flex gap="500" a="center">
         <div className={styles.value} onClick={onStartEdit}>
-          {value}
+          {localValue}
         </div>
       </j-flex>
     );
   }
 
-  if (value?.constructor?.name === "Object") {
-    return <ShowObjectInfo value={value} />;
+  if (localValue?.constructor?.name === "Object") {
+    return <ShowObjectInfo value={localValue} />;
   }
 
-  if (value === true) return <j-toggle size="sm" checked></j-toggle>;
+  if (localValue === true) return <j-toggle size="sm" checked></j-toggle>;
 
-  if (value === false)
+  if (localValue === false)
     return onUpdate ? (
       <j-button onClick={onStartEdit} square circle size="sm" variant="ghost">
         <j-icon size="xs" name="pencil"></j-icon>
@@ -163,7 +172,7 @@ export default function DisplayValue({
       <span></span>
     );
 
-  return value === null ? <span></span> : value;
+  return localValue === null ? <span></span> : localValue;
 }
 
 function ShowObjectInfo({ value }) {

--- a/views/kanban-view/src/components/Entry/Entry.tsx
+++ b/views/kanban-view/src/components/Entry/Entry.tsx
@@ -1,32 +1,24 @@
-import { PerspectiveProxy } from "@coasys/ad4m";
+import { Ad4mModel, PerspectiveProxy } from "@coasys/ad4m";
 import { useModel } from "@coasys/ad4m-react-hooks";
 import { useEffect, useState } from "preact/hooks";
 import DisplayValue from "../DisplayValue";
 
 type Props = {
   perspective: PerspectiveProxy;
-  id: string;
+  task: Ad4mModel;
   channelId: string;
   selectedClass: string;
   onUrlClick?: Function;
 };
 
-export function capitalize(str: string) {
-  return str.charAt(0).toUpperCase() + str.slice(1);
-}
-function propertyNameToSetterName(property: string): string {
-  return `set${capitalize(property)}`
-}
-
 export default function Entry({
   perspective,
-  id,
+  task,
   channelId,
   selectedClass,
   onUrlClick = () => {},
 }: Props) {
   const [namedOptions, setNamedOptions] = useState({});
-  const { entries } = useModel({ perspective, model: selectedClass, query: { where: { base: id } } });
 
   useEffect(() => {
     perspective
@@ -50,13 +42,12 @@ export default function Entry({
   }, [selectedClass, perspective.uuid]);
 
   async function onUpdate(propName, value) {
-    const model = await perspective.getSubjectProxy(entries[0]?.baseExpression, selectedClass) as any;
-    const setterName = propertyNameToSetterName(propName);
-    await model[setterName](value);
+    task[propName] = value;
+    await task.update();
   }
 
-  if (entries[0]) {
-    const properties = Object.entries(entries[0]).filter(([key, value]) => {
+  if (task) {
+    const properties = Object.entries(task).filter(([key, value]) => {
       return !(
         key === "author" ||
         key === "timestamp" ||
@@ -66,13 +57,14 @@ export default function Entry({
       );
     });
 
-    const titleName = entries[0].hasOwnProperty("name")
+    const titleName = task.hasOwnProperty("name")
       ? "name"
-      : entries[0].hasOwnProperty("title")
+      : task.hasOwnProperty("title")
         ? "title"
         : "";
 
-    const defaultName = entries[0]?.name || entries[0]?.title || "";
+    // @ts-ignore
+    const defaultName = task?.name || task?.title || "";
 
     return (
       <div>
@@ -130,5 +122,5 @@ export default function Entry({
     );
   }
 
-  return <span>{id}</span>;
+  return <span>{task.baseExpression}</span>;
 }

--- a/views/kanban-view/src/components/Entry/Entry.tsx
+++ b/views/kanban-view/src/components/Entry/Entry.tsx
@@ -11,6 +11,13 @@ type Props = {
   onUrlClick?: Function;
 };
 
+export function capitalize(str: string) {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+function propertyNameToSetterName(property: string): string {
+  return `set${capitalize(property)}`
+}
+
 export default function Entry({
   perspective,
   id,
@@ -44,9 +51,8 @@ export default function Entry({
 
   async function onUpdate(propName, value) {
     const model = await perspective.getSubjectProxy(entries[0]?.baseExpression, selectedClass) as any;
-    const entry = new model(perspective, entries[0]?.baseExpression, id);
-    entry[propName] = value;
-    await entry.update();
+    const setterName = propertyNameToSetterName(propName);
+    await model[setterName](value);
   }
 
   if (entries[0]) {


### PR DESCRIPTION
Use Ad4mModel in Kanban view and get a subscriptions for the collection of tasks on Board level, pass-in Ad4mModel objects into other components.

Also pulled out a profile cache on Board level to make rendering of cards a bit faster. Should be wired up with the other new app wide cache.

Needs these fixes in AD4M: https://github.com/coasys/ad4m/pull/603