### PR TITLE
Transcriber updates

### DIFF
--- a/app/src/components/transcriber/Transcriber.vue
+++ b/app/src/components/transcriber/Transcriber.vue
@@ -46,14 +46,44 @@
     <j-box mb="300">
       <j-flex gap="400" j="between" a="center">
         <j-text nomargin uppercase size="400" weight="800" color="primary-500">Transcriber</j-text>
-        <template v-if="browser === 'chrome'">
-          <j-checkbox :checked="useRemoteService" @change="toggleRemoteService" size="sm">
-            <j-text nomargin>Use Google transcription</j-text>
-          </j-checkbox>
-        </template>
-        <template v-else>
-          <j-text>Google transcription available in Chrome</j-text>
-        </template>
+        <j-flex a="center">
+          <j-tooltip
+            :placement="'top'"
+            :title="`${browser === 'chrome' ? 'Use' : 'Using'} local AI for transcription`"
+            style="margin-right: 12px; height: 22px"
+            :style="{ cursor: browser === 'chrome' ? 'pointer' : 'default' }"
+          >
+            <Ad4mLogo
+              width="22"
+              height="22"
+              :color="`var(--j-color-primary-${useRemoteService ? 300 : 500})`"
+              @click="browser === 'chrome' && toggleRemoteService()"
+            />
+          </j-tooltip>
+          <j-toggle
+            :checked="browser === 'chrome' && useRemoteService"
+            :disabled="browser !== 'chrome'"
+            @change="toggleRemoteService"
+            size="sm"
+          />
+          <j-tooltip
+            :placement="'top'"
+            :title="
+              browser === 'chrome'
+                ? 'Use Google AI for transcription'
+                : 'Open Flux in Chrome to enable Google AI transcription'
+            "
+            style="margin-left: -5px; height: 22px"
+            :style="{ cursor: browser === 'chrome' ? 'pointer' : 'default' }"
+          >
+            <j-icon
+              name="google"
+              size="sm"
+              :color="useRemoteService ? 'primary-500' : 'primary-300'"
+              @click="browser === 'chrome' && toggleRemoteService()"
+            />
+          </j-tooltip>
+        </j-flex>
       </j-flex>
     </j-box>
     <j-flex v-if="mediaSettings.audioEnabled" gap="300" a="center">
@@ -71,6 +101,7 @@
 </template>
 
 <script setup lang="ts">
+import Ad4mLogo from "@/components/ad4m-logo/Ad4mLogo.vue";
 import RecordingIcon from "@/components/recording-icon/RecordingIcon.vue";
 import { useAiStore, useMediaDevicesStore, useWebrtcStore } from "@/stores";
 import { PerspectiveProxy } from "@coasys/ad4m";

--- a/app/src/components/transcriber/Transcriber.vue
+++ b/app/src/components/transcriber/Transcriber.vue
@@ -288,12 +288,13 @@ function startRemoteTranscription() {
   };
 
   recognition.value.onerror = (event: any) => {
+    if (event.error === "no-speech") return; // Ignore no-speech errors (fires whenever user stops speaking)
     console.error("Speech recognition error:", event.error);
   };
 
   recognition.value.onend = () => {
     // Restart if ended due to timeout (not user toggling to local service)
-    if (usingRemoteService.value) recognition.value.start();
+    if (usingRemoteService.value && recognition.value) recognition.value.start();
   };
 
   recognition.value.start();
@@ -344,9 +345,7 @@ async function startLocalTransciption(stream: MediaStream) {
 function startListening() {
   listening.value = true;
   navigator.mediaDevices
-    .getUserMedia({
-      audio: { echoCancellation: true, noiseSuppression: true },
-    })
+    .getUserMedia({ audio: { echoCancellation: true, noiseSuppression: true } })
     .then(async (stream) => {
       audioContext.value = new (window.AudioContext || (window as any).webkitAudioContext)();
       if (useRemoteService.value) startRemoteTranscription();

--- a/app/src/containers/CallWindow.vue
+++ b/app/src/containers/CallWindow.vue
@@ -124,9 +124,12 @@
               <j-icon name="gear" color="ui-500" @click="router.push({ name: 'settings' })" />
             </j-tooltip>
 
-            <j-tooltip :placement="'top'" :title="`${callWindowOpen ? 'Hide' : 'Show'} call window`">
+            <j-tooltip
+              v-if="inCall || route.params.channelId"
+              :placement="'top'"
+              :title="`${callWindowOpen ? 'Hide' : 'Show'} call window`"
+            >
               <j-icon
-                v-if="inCall || route.params.channelId"
                 :name="`arrows-angle-${callWindowOpen ? 'contract' : 'expand'}`"
                 color="ui-500"
                 @click="() => uiStore.setCallWindowOpen(!callWindowOpen)"


### PR DESCRIPTION
- Speech recognition errors handled:
   - "no-speech" error now ignored as fires whenever user stops speaking
   - Presence of `recognition` ref checked before restarting at `"onended"` event.

- New transcriber AI toggle set up with Adam and Google logo buttons and tooltips to display more info on hover

- `v-if` condition moved from the expand/contact icon to parent tooltip in the call window controls to prevent padding issue when icon not present