### PR TITLE
WebRTC call fixes

### DIFF
--- a/app/src/components/media-player/MediaPlayer.vue
+++ b/app/src/components/media-player/MediaPlayer.vue
@@ -84,6 +84,7 @@ const props = defineProps({
   isMe: { type: Boolean, default: false },
   inCall: { type: Boolean, default: false },
   stream: { type: MediaStream, default: null },
+  streamReady: { type: Boolean, default: false },
   audioState: { type: String as PropType<MediaState>, default: "on" },
   videoState: { type: String as PropType<MediaState>, default: "off" },
   screenShareState: { type: String as PropType<MediaState>, default: "off" },
@@ -103,6 +104,7 @@ const profile = ref<Profile>();
 const showVideo = computed(() => stream && (props.videoState === "on" || props.screenShareState === "on"));
 const flipVideo = computed(() => props.isMe && props.screenShareState !== "on");
 const loadingMessage = computed(() => {
+  if (!props.streamReady) return "Loading...";
   if (props.videoState === "loading") return "Video loading...";
   else if (props.screenShareState === "loading") return "Screenshare loading...";
   return "";
@@ -180,9 +182,6 @@ onMounted(async () => (profile.value = await getCachedAgentProfile(did.value)));
       color: white;
       background: #0000002e;
       border-radius: 10rem;
-    }
-
-    .settings {
     }
   }
 }

--- a/app/src/composables/useSignallingService.ts
+++ b/app/src/composables/useSignallingService.ts
@@ -4,7 +4,7 @@ import { AgentState, AgentStatus, ProcessingState, SignallingService } from "@co
 import { storeToRefs } from "pinia";
 import { ref, watch } from "vue";
 
-const HEARTBEAT_INTERVAL = 5000; // 5 seconds between heartbeats
+export const HEARTBEAT_INTERVAL = 5000; // 5 seconds between heartbeats
 const CLEANUP_INTERVAL = 10000; // 10 seconds between evaluations
 const ASLEEP_THRESHOLD = 30000; // 30 seconds before "asleep"
 const MAX_AGE = 60000; // 60 seconds before "offline"

--- a/app/src/containers/CallWindow.vue
+++ b/app/src/containers/CallWindow.vue
@@ -185,10 +185,12 @@
             <template v-if="selectedVideoLayout.label === 'Focused'">
               <!-- Main focused video -->
               <MediaPlayer
+                :key="focusedParticipant.did"
                 :did="focusedParticipant.did"
                 :isMe="focusedParticipant.isMe"
                 :inCall="focusedParticipant.inCall"
                 :stream="focusedParticipant.stream"
+                :streamReady="focusedParticipant.streamReady"
                 :audioState="focusedParticipant.audioState"
                 :videoState="focusedParticipant.videoState"
                 :screenShareState="focusedParticipant.screenShareState"
@@ -208,6 +210,7 @@
                     :isMe="participant.isMe"
                     :inCall="participant.inCall"
                     :stream="participant.stream"
+                    :streamReady="participant.streamReady"
                     :audioState="participant.audioState"
                     :videoState="participant.videoState"
                     :screenShareState="participant.screenShareState"
@@ -228,6 +231,7 @@
                 :isMe="participant.isMe"
                 :inCall="participant.inCall"
                 :stream="participant.stream"
+                :streamReady="participant.streamReady"
                 :audioState="participant.audioState"
                 :videoState="participant.videoState"
                 :screenShareState="participant.screenShareState"
@@ -461,6 +465,7 @@ const allParticipants = computed(() => {
     did: me.value.did,
     inCall: inCall.value,
     stream: stream.value || undefined,
+    streamReady: true,
     audioState: (audioEnabled ? "on" : "off") as MediaState,
     videoState: (videoEnabled ? "on" : "off") as MediaState,
     screenShareState: (screenShareEnabled ? "on" : "off") as MediaState,
@@ -472,6 +477,7 @@ const allParticipants = computed(() => {
     did: peer.did,
     inCall: true,
     stream: peer.streams?.[0] || undefined,
+    streamReady: peer.streamReady,
     audioState: peer.audioState,
     videoState: peer.videoState,
     screenShareState: peer.screenShareState,


### PR DESCRIPTION
- Stream ready loading state set up so we can display a loading placeholder in the MediaPlayer until tracks are ready
- Disconnected peers tracked & timeout added to prevent re-connection attempts after a peer leaves a call but before their state has updated in the signalling service.
- Key prop added to the focused MediaPlayer to prevent stale state errors when a user leaves the call, and new console logs added for testing
- toggleVideo function updated to distinguish between screen share tracks and regular video tracks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Media players now indicate when a participant's media stream is ready, improving feedback during call setup.
  - The app tracks and displays the readiness state of participant video streams in all call layouts.

- **Bug Fixes**
  - Prevents immediate reconnection attempts to recently disconnected peers, reducing potential connection issues.

- **Improvements**
  - Enhanced identification and handling of screen share video tracks for more reliable toggling of video streams.
  - Improved loading messages and feedback for media streams.
  - Additional logging for debugging media loading and track replacement events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->