### PR TITLE
Webrtc call fixes 2

### DIFF
--- a/app/src/components/media-player/MediaPlayer.vue
+++ b/app/src/components/media-player/MediaPlayer.vue
@@ -33,7 +33,7 @@
 
     <div v-if="loadingMessage" class="loading-message">
       <j-spinner />
-      <j-text>{{ loadingMessage }}</j-text>
+      <j-text nomargin>{{ loadingMessage }}</j-text>
     </div>
 
     <j-flex v-if="emojis.length" class="emojis" gap="400">
@@ -153,7 +153,7 @@ onMounted(async () => (profile.value = await getCachedAgentProfile(did.value)));
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    gap: var(--j-space-400);
+    gap: var(--j-space-500);
     background: var(--j-color-ui-50);
     z-index: 3;
   }

--- a/app/src/components/transcriber/Transcriber.vue
+++ b/app/src/components/transcriber/Transcriber.vue
@@ -116,7 +116,7 @@ const mediaDevicesStore = useMediaDevicesStore();
 const aiStore = useAiStore();
 const webrtcStore = useWebrtcStore();
 
-const { mediaSettings } = storeToRefs(mediaDevicesStore);
+const { mediaSettings, activeMicrophoneId } = storeToRefs(mediaDevicesStore);
 const { transcriptionMessageTimeout } = storeToRefs(aiStore);
 const { callRoute } = storeToRefs(webrtcStore);
 
@@ -438,7 +438,6 @@ function toggleRemoteService() {
   useRemoteService.value = !useRemoteService.value;
 }
 
-// Lifecycle hooks
 onMounted(() => {
   if (mediaSettings.value.audioEnabled) startListening();
 });
@@ -462,6 +461,16 @@ watch(useRemoteService, () => {
     stopListening();
     startListening();
   }
+});
+
+// Watch for microphone changes
+watch(activeMicrophoneId, () => {
+  console.log("Microphone change detected in the transcriber");
+  // Restart listening with new microphone
+  stopListening();
+  setTimeout(() => {
+    if (mediaSettings.value.audioEnabled) startListening();
+  }, 1000);
 });
 </script>
 

--- a/app/src/containers/CallWindow.vue
+++ b/app/src/containers/CallWindow.vue
@@ -597,20 +597,20 @@ function focusOnVideo(did: string) {
   }
 }
 
+function closeFocusedVideoLayout() {
+  selectedVideoLayout.value = videoLayoutOptions[0];
+  focusedVideoId.value = "";
+}
+
 // Reset layout & focused video when the call window opens
 // TODO: based this on leaving the call, not just opening the window, & store preferences in the webrtc store
 watch(callWindowOpen, (open) => {
-  if (open) {
-    selectedVideoLayout.value = videoLayoutOptions[0];
-    focusedVideoId.value = "";
-  }
+  if (open) closeFocusedVideoLayout();
 });
 
 watch(disconnectedAgents, (disconnected) => {
-  // Reset focused video if the disconnected agent was focused
-  if (focusedVideoId.value && disconnected.includes(focusedVideoId.value)) {
-    focusedVideoId.value = me.value.did;
-  }
+  // Toggle off the focused video layout if the disconnected agent was focused
+  if (focusedVideoId.value && disconnected.includes(focusedVideoId.value)) closeFocusedVideoLayout();
 });
 
 onMounted(getMyProfile);

--- a/app/src/containers/CallWindow.vue
+++ b/app/src/containers/CallWindow.vue
@@ -598,6 +598,7 @@ function focusOnVideo(did: string) {
 }
 
 function closeFocusedVideoLayout() {
+  console.log("*** closeFocusedVideoLayout called");
   selectedVideoLayout.value = videoLayoutOptions[0];
   focusedVideoId.value = "";
 }
@@ -610,6 +611,8 @@ watch(callWindowOpen, (open) => {
 
 watch(disconnectedAgents, (disconnected) => {
   // Toggle off the focused video layout if the disconnected agent was focused
+  console.log("*** Disconnected agents updated in call window:", disconnected);
+  console.log("*** focusedVideoId.value:", focusedVideoId.value);
   if (focusedVideoId.value && disconnected.includes(focusedVideoId.value)) closeFocusedVideoLayout();
 });
 

--- a/app/src/containers/CallWindow.vue
+++ b/app/src/containers/CallWindow.vue
@@ -426,6 +426,7 @@ const {
   callChannelName,
   myAgentStatus,
   peerConnections,
+  disconnectedAgents,
 } = storeToRefs(webrtcStore);
 
 type LayoutOption = { label: string; class: string; icon: string };
@@ -602,6 +603,13 @@ watch(callWindowOpen, (open) => {
   if (open) {
     selectedVideoLayout.value = videoLayoutOptions[0];
     focusedVideoId.value = "";
+  }
+});
+
+watch(disconnectedAgents, (disconnected) => {
+  // Reset focused video if the disconnected agent was focused
+  if (focusedVideoId.value && disconnected.includes(focusedVideoId.value)) {
+    focusedVideoId.value = me.value.did;
   }
 });
 

--- a/app/src/containers/CallWindow.vue
+++ b/app/src/containers/CallWindow.vue
@@ -598,7 +598,6 @@ function focusOnVideo(did: string) {
 }
 
 function closeFocusedVideoLayout() {
-  console.log("*** closeFocusedVideoLayout called");
   selectedVideoLayout.value = videoLayoutOptions[0];
   focusedVideoId.value = "";
 }
@@ -609,12 +608,10 @@ watch(callWindowOpen, (open) => {
   if (open) closeFocusedVideoLayout();
 });
 
+// Watch disconnected agents and toggle off the focused video layout if the disconnected agent was focused
 watch(
   disconnectedAgents,
   (disconnected) => {
-    // Toggle off the focused video layout if the disconnected agent was focused
-    console.log("*** Disconnected agents updated in call window:", disconnected);
-    console.log("*** focusedVideoId.value:", focusedVideoId.value);
     if (focusedVideoId.value && disconnected.includes(focusedVideoId.value)) closeFocusedVideoLayout();
   },
   { deep: true }

--- a/app/src/containers/CallWindow.vue
+++ b/app/src/containers/CallWindow.vue
@@ -609,12 +609,16 @@ watch(callWindowOpen, (open) => {
   if (open) closeFocusedVideoLayout();
 });
 
-watch(disconnectedAgents, (disconnected) => {
-  // Toggle off the focused video layout if the disconnected agent was focused
-  console.log("*** Disconnected agents updated in call window:", disconnected);
-  console.log("*** focusedVideoId.value:", focusedVideoId.value);
-  if (focusedVideoId.value && disconnected.includes(focusedVideoId.value)) closeFocusedVideoLayout();
-});
+watch(
+  disconnectedAgents,
+  (disconnected) => {
+    // Toggle off the focused video layout if the disconnected agent was focused
+    console.log("*** Disconnected agents updated in call window:", disconnected);
+    console.log("*** focusedVideoId.value:", focusedVideoId.value);
+    if (focusedVideoId.value && disconnected.includes(focusedVideoId.value)) closeFocusedVideoLayout();
+  },
+  { deep: true }
+);
 
 onMounted(getMyProfile);
 </script>

--- a/app/src/stores/mediaDevicesStore.ts
+++ b/app/src/stores/mediaDevicesStore.ts
@@ -318,7 +318,7 @@ export const useMediaDevicesStore = defineStore(
             videoEnabled.value = false;
           }
         }
-      } else {
+      } else if (!screenShareEnabled.value) {
         // Disabling video - disable tracks with animation delay
         await new Promise((resolve) => setTimeout(resolve, 300)); // Fade out animation
         existingVideoTracks.forEach((track) => (track.enabled = false));

--- a/app/src/stores/mediaDevicesStore.ts
+++ b/app/src/stores/mediaDevicesStore.ts
@@ -298,21 +298,6 @@ export const useMediaDevicesStore = defineStore(
 
             console.log("✅ Added new video track");
           } catch (error) {
-            if (error.name === "OverconstrainedError") {
-              console.error("❌ Overconstrained:", {
-                constraint: error.constraint, // Which constraint failed
-                message: error.message,
-                requestedConstraints: videoConstraints,
-              });
-
-              // Log available devices for debugging
-              const devices = await navigator.mediaDevices.enumerateDevices();
-              console.log(
-                "Available video devices:",
-                devices.filter((d) => d.kind === "videoinput")
-              );
-            }
-
             console.error("❌ Failed to add video track:", error);
             // Revert the state if it failed
             videoEnabled.value = false;

--- a/app/src/stores/webrtcStore.ts
+++ b/app/src/stores/webrtcStore.ts
@@ -240,7 +240,7 @@ export const useWebrtcStore = defineStore(
         // }, 1000);
       });
 
-      peer.on("data", (signal) => {
+      peer.on("data", async (signal) => {
         let parsedSignal;
         try {
           parsedSignal = JSON.parse(signal);
@@ -276,8 +276,6 @@ export const useWebrtcStore = defineStore(
             peer.screenShareState = data.enabled ? "loading" : "off";
             if (data.enabled) startLoadingCheck("screenshare", peer);
           }
-
-          console.log(`Peer ${did} updated media settings:`, data);
         }
 
         if (type === WEBRTC_LEAVING_CALL) {
@@ -285,7 +283,6 @@ export const useWebrtcStore = defineStore(
 
           // Add the agents did to the disconnected agents list for a full HEARTBEAT_INTERVAL to avoid reconnection attempts until the signalling service is up to date
           disconnectedAgents.value.push(did);
-          console.log("*** New disconnected agents in webrtc store:", disconnectedAgents.value);
           setTimeout(
             () => (disconnectedAgents.value = disconnectedAgents.value.filter((d) => d !== did)),
             HEARTBEAT_INTERVAL + 1000
@@ -293,7 +290,8 @@ export const useWebrtcStore = defineStore(
 
           // Clean up the peer connection
           cleanupPeerConnection(did);
-          appStore.showDangerToast({ message: `${did} has left the call` });
+          const peerProfile = await getCachedAgentProfile(did);
+          appStore.showDangerToast({ message: `👤 ${peerProfile.username || did} has left the call` });
         }
       });
 

--- a/app/src/stores/webrtcStore.ts
+++ b/app/src/stores/webrtcStore.ts
@@ -285,6 +285,7 @@ export const useWebrtcStore = defineStore(
 
           // Add the agents did to the disconnected agents list for a full HEARTBEAT_INTERVAL to avoid reconnection attempts until the signalling service is up to date
           disconnectedAgents.value.push(did);
+          console.log("*** New disconnected agents in webrtc store:", disconnectedAgents.value);
           setTimeout(
             () => (disconnectedAgents.value = disconnectedAgents.value.filter((d) => d !== did)),
             HEARTBEAT_INTERVAL + 1000

--- a/app/src/stores/webrtcStore.ts
+++ b/app/src/stores/webrtcStore.ts
@@ -14,7 +14,7 @@ import { computed, ref, watch } from "vue";
 import { useRoute } from "vue-router";
 import { useAppStore } from "./appStore";
 import { useCommunityServiceStore } from "./communityServiceStore";
-import { FluxTrack, useMediaDevicesStore } from "./mediaDevicesStore";
+import { useMediaDevicesStore } from "./mediaDevicesStore";
 import { useUiStore } from "./uiStore";
 // @ts-ignore
 import SimplePeer from "simple-peer/simplepeer.min.js";
@@ -172,10 +172,10 @@ export const useWebrtcStore = defineStore(
             hasMedia = stream.getAudioTracks().length > 0;
             break;
           case "video":
-            hasMedia = stream.getVideoTracks().some((track: FluxTrack) => track.mediaType === "camera");
+            hasMedia = stream.getVideoTracks().some((track) => track.enabled);
             break;
           case "screenshare":
-            hasMedia = stream.getVideoTracks().some((track: FluxTrack) => track.mediaType === "screenshare");
+            hasMedia = stream.getVideoTracks().some((track) => track.enabled);
             break;
         }
 
@@ -263,9 +263,7 @@ export const useWebrtcStore = defineStore(
             peer.audioState = data.enabled ? "loading" : "off";
             if (data.enabled) startLoadingCheck("audio", peer);
           } else if (data.type === "video") {
-            const existingVideoTrack = peer.streams[0]
-              .getVideoTracks()
-              .some((track: FluxTrack) => track.mediaType === "camera");
+            const existingVideoTrack = peer.streams[0].getVideoTracks().some((track) => track.enabled);
             // If toggling back on an existing video track or switching on video while screen sharing is enabled, skip the video loading state
             if (data.enabled && (existingVideoTrack || peer.screenShareState === "on")) {
               peer.videoState = "on";
@@ -299,7 +297,7 @@ export const useWebrtcStore = defineStore(
       });
 
       peer.on("track", (track, stream) => {
-        console.log(`🎞️ New ${(track as FluxTrack).mediaType} track from ${did}`, track);
+        console.log(`🎞️ New ${track.kind} track from ${did}`, track);
 
         // Find the peer connection
         const peerConnection = peerConnections.value.get(did);
@@ -481,7 +479,7 @@ export const useWebrtcStore = defineStore(
       console.log("🎉 Finished updating audio tracks for all peers");
     }
 
-    async function replaceVideoTrack(newTrack: FluxTrack, oldTrack?: FluxTrack) {
+    async function replaceVideoTrack(newTrack: MediaStreamTrack, oldTrack?: MediaStreamTrack) {
       if (!inCall.value) return;
 
       console.log("📹 Replacing video track for all peers", newTrack);


### PR DESCRIPTION
- `MediaPlayer` loading state logic & UI styling fixes
- WebRTC data channel signal set up for leaving a call so we can better manage the disconnected agents state, avoiding unwanted re-connection attempts & enabling us to reset the focused video layout if the agent leaving the call was focused in the video wall at the time of leaving
- Transcriber hooked up with microphone selected in the media devices store & transcription restarted when mic changed
- `exact` replaced with `ideal` microphone & camera constraints so we can fall back on working constraints if specified constraints aren't met

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - The call window now automatically switches video focus to your own feed if the currently focused participant disconnects.
  - Improved detection and handling of participants leaving a call, with clearer notifications when someone exits.
- **Improvements**
  - Updated visual spacing and margins in the media player’s loading message for a cleaner appearance.
  - Refined media device permission handling and error logging for better reliability and debugging.
  - Transcription service now automatically restarts when the active microphone changes for seamless audio input switching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->