### PR TITLE
Start new conversation button

### DIFF
--- a/packages/api/src/conversation/util.ts
+++ b/packages/api/src/conversation/util.ts
@@ -1,8 +1,10 @@
 import { AIClient } from "@coasys/ad4m";
+import { languages } from "@coasys/flux-constants";
 import Embedding from "../embedding";
 import SemanticRelationship from "../semantic-relationship";
-import { languages } from "@coasys/flux-constants";
+
 const { EMBEDDING_VECTOR_LANGUAGE } = languages;
+const showLogs = false; // Set to true to enable debug logs
 
 async function findEmbeddingSRId(perspective, itemId): Promise<string | null> {
   const result = await perspective.infer(`
@@ -25,7 +27,7 @@ async function findEmbeddingSRId(perspective, itemId): Promise<string | null> {
 export async function removeEmbedding(perspective, itemId, batchId: string): Promise<void> {
   const embeddingSRId = await findEmbeddingSRId(perspective, itemId);
   if (embeddingSRId) {
-    console.log('embeddingSRId found:', embeddingSRId);
+    if (showLogs) console.log("embeddingSRId found:", embeddingSRId);
     const semanticRelationship = await new SemanticRelationship(perspective, embeddingSRId);
     const { tag } = await semanticRelationship.get();
     const embedding = new Embedding(perspective, tag);
@@ -39,22 +41,29 @@ function duration(start, end) {
 }
 
 // todo: use embedding language instead of stringifying
-export async function createEmbedding(perspective, text, itemId, ai: AIClient, batchId: string, index?: number): Promise<void> {
+export async function createEmbedding(
+  perspective,
+  text,
+  itemId,
+  ai: AIClient,
+  batchId: string,
+  index?: number
+): Promise<void> {
   // generate embedding
   const start1 = new Date().getTime();
   const rawEmbedding = await ai.embed("bert", text);
   const end1 = new Date().getTime();
-  console.log(`${index ? `Item ${index} e` : "E"}mbedding created in ${duration(start1, end1)}`);
+  if (showLogs) console.log(`${index ? `Item ${index} e` : "E"}mbedding created in ${duration(start1, end1)}`);
   // create embedding subject entity
   const start2 = new Date().getTime();
   const embedding = new Embedding(perspective, undefined, itemId);
   embedding.model = "bert";
   const embeddingExpression = await perspective.createExpression(rawEmbedding, EMBEDDING_VECTOR_LANGUAGE);
-  console.log(`embeddingExpression for item ${index}:`, embeddingExpression);
+  if (showLogs) console.log(`embeddingExpression for item ${index}:`, embeddingExpression);
   embedding.embedding = embeddingExpression;
   await embedding.save(batchId);
   const end2 = new Date().getTime();
-  console.log(`${index ? `Item ${index} e` : "E"}mbedding saved in ${duration(start2, end2)}`);
+  if (showLogs) console.log(`${index ? `Item ${index} e` : "E"}mbedding saved in ${duration(start2, end2)}`);
   // create semantic relationship subject entity
   const start3 = new Date().getTime();
   const relationship = new SemanticRelationship(perspective, undefined, itemId);
@@ -62,5 +71,5 @@ export async function createEmbedding(perspective, text, itemId, ai: AIClient, b
   relationship.tag = embedding.baseExpression;
   await relationship.save(batchId);
   const end3 = new Date().getTime();
-  console.log(`${index ? `Item ${index}` : ""} SR saved in ${duration(start3, end3)}`);
+  if (showLogs) console.log(`${index ? `Item ${index}` : ""} SR saved in ${duration(start3, end3)}`);
 }


### PR DESCRIPTION
- New "Start new conversation" button set up so users can manually initialize a new conversation in the Synergy view
- `processItems()` function updated to split items between conversations based on whether their timestamp is before or after the creation of the current conversation
- Old time based conversation splitting logic removed
- `showLogs` boolean (current default = false) added to synergy processing files so we can easily toggle on and off processing logs