### PR TITLE
fix: properly unwrap perspectives ref in hasJoinedTestingCommunity

### DIFF
--- a/app/src/views/main/MainView.vue
+++ b/app/src/views/main/MainView.vue
@@ -201,7 +201,7 @@ const isJoining = ref(false);
 const hasCopied = ref(false);
 
 const hasJoinedTestingCommunity = computed(() => {
-  return !!Object.values(perspectives).find((p) => p.sharedUrl === DEFAULT_TESTING_NEIGHBOURHOOD);
+  return !!Object.values(perspectives.value).find((p) => p.sharedUrl === DEFAULT_TESTING_NEIGHBOURHOOD);
 });
 
 async function leaveCommunity() {


### PR DESCRIPTION
`.value` added to properly unwrap perspectives ref in `hasJoinedTestingCommunity` computed property

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Fixed detection of whether you’ve joined the Testing Community, ensuring your membership status is accurately reflected in the Main view.
  - Resolves occasional misreporting that could show incorrect join prompts, status badges, or CTA buttons.
  - Improves consistency of related UI elements, preventing unnecessary prompts and ensuring access to community-specific content appears only when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->