### PR TITLE
Fix Web2 link meta fetch interrupting user input and automatically bumping the cursor to the next input field

### DIFF
--- a/app/src/views/main/profile/WebLinkCard.vue
+++ b/app/src/views/main/profile/WebLinkCard.vue
@@ -6,7 +6,7 @@
     </div>
 
     <div class="link-card__content">
-      <a :href="url" target="_blank" class="link-card__info">
+      <a :href="safeUrl" target="_blank" rel="noopener noreferrer" class="link-card__info">
         <h2 class="link-card__title">{{ title || url }}</h2>
 
         <div class="link-card__description" v-if="description">{{ description }}</div>
@@ -39,10 +39,19 @@ const emit = defineEmits(["delete", "edit"]);
 
 const { ad4mClient } = useAppStore();
 
+function normalizeUrl(input: string): string {
+  const value = (input || "").trim();
+  if (!value) return "";
+  const hasScheme = /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(value);
+  return hasScheme ? value : `https://${value}`;
+}
+
+const safeUrl = computed(() => normalizeUrl(props.url));
+
 const hostname = computed(() => {
-  if (props.url) {
+  if (safeUrl.value) {
     try {
-      return new URL(props.url).hostname;
+      return new URL(safeUrl.value).hostname;
     } catch (e) {
       return "";
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic URL normalization (adds https:// when missing) in add and card views.
  * Debounced metadata fetching for smoother input.
  * Input field switched to text for easier editing.

* **Bug Fixes**
  * Safer external links using rel="noopener noreferrer" and normalized URLs.
  * Validates and fetches metadata only for host-like, valid URLs; prevents empty/invalid requests.
  * More reliable hostname display and link opening via normalized, parsed URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->