### PR TITLE
Fix for broken stream on video grid layout changes

### DIFF
--- a/app/src/components/media-player/MediaPlayer.vue
+++ b/app/src/components/media-player/MediaPlayer.vue
@@ -143,22 +143,25 @@ watch(
 
 // Ensure proper cleanup
 onBeforeUnmount(() => {
-  if (videoElement.value) videoElement.value.srcObject = null;
+  if (videoElement.value) {
+    videoElement.value.pause();
+    videoElement.value.srcObject = null;
+  }
 });
 
 onMounted(async () => {
-  // Get user profile
-  profile.value = await getCachedAgentProfile(did.value);
   // Attach stream to video element if not already set
   if (stream.value && videoElement.value && !videoElement.value.srcObject) {
     try {
       videoElement.value.srcObject = stream.value;
       await nextTick();
-      if (videoElement.value.paused) await videoElement.value.play().catch(() => {});
+      if (videoElement.value.paused) await videoElement.value.play();
     } catch (e) {
       console.warn('Mount attach stream failed', e);
     }
   }
+  // Get user profile
+  profile.value = await getCachedAgentProfile(did.value);
 });
 </script>
 

--- a/app/src/components/media-player/MediaPlayer.vue
+++ b/app/src/components/media-player/MediaPlayer.vue
@@ -146,8 +146,20 @@ onBeforeUnmount(() => {
   if (videoElement.value) videoElement.value.srcObject = null;
 });
 
-// Get profile on mount
-onMounted(async () => (profile.value = await getCachedAgentProfile(did.value)));
+onMounted(async () => {
+  // Get user profile
+  profile.value = await getCachedAgentProfile(did.value);
+  // Attach stream to video element if not already set
+  if (stream.value && videoElement.value && !videoElement.value.srcObject) {
+    try {
+      videoElement.value.srcObject = stream.value;
+      await nextTick();
+      if (videoElement.value.paused) await videoElement.value.play().catch(() => {});
+    } catch (e) {
+      console.warn('Mount attach stream failed', e);
+    }
+  }
+});
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Media Player now reliably attaches an available live stream on load and starts playback automatically, reducing cases where video remains paused or blank.
  - Cleanup on unmount now pauses playback before detaching the stream to ensure the video stops cleanly.

- **Improvements**
  - Startup order adjusted to attach stream earlier for smoother initialization.
  - Improved error handling for stream attachment to avoid startup interruptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->