### PR TITLE
Conversation item author fix

### DIFF
--- a/packages/api/src/conversation-subgroup/index.ts
+++ b/packages/api/src/conversation-subgroup/index.ts
@@ -193,8 +193,8 @@ export default class ConversationSubgroup extends Ad4mModel {
       const surrealQuery = `
         SELECT
           out.uri AS baseExpression,
-          author,
           timestamp,
+          out->link[WHERE predicate = 'flux://entry_type'][0].author AS author,
           out->link[WHERE predicate = 'flux://entry_type'][0].out.uri AS type,
           fn::parse_literal(out->link[WHERE predicate = 'flux://body'][0].out.uri) AS messageBody,
           fn::parse_literal(out->link[WHERE predicate = 'flux://title'][0].out.uri) AS postTitle,


### PR DESCRIPTION
Conversation items author now retrieved from the items `entry_type` link instead of its `has_child` link to the subgroup, which is authored by the LLM processor, not the items author.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal data retrieval logic to optimize author field extraction in conversation data queries. No end-user visible changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->