### PR TITLE
neighbourhoodProxy.otherAgents() results deduplicated

### DIFF
--- a/app/src/composables/useCommunityService.ts
+++ b/app/src/composables/useCommunityService.ts
@@ -175,7 +175,7 @@ export async function createCommunityService(): Promise<CommunityService> {
     try {
       membersLoading.value = true;
       const others = (await neighbourhood?.otherAgents()) || [];
-      const allMembersDids = [...others, me.value.did];
+      const allMembersDids = [...new Set([...others, me.value.did])];
       // Pre-fill members with partial profiles to speed up display
       members.value = allMembersDids.map((did) => ({ did, profileThumbnailPicture: undefined }));
       // Fetch full profiles with images

--- a/packages/flux-editor/src/flux-editor.ts
+++ b/packages/flux-editor/src/flux-editor.ts
@@ -331,7 +331,7 @@ export default class MyElement extends LitElement {
       const me = await this.agent.me();
       const neighbourhood = this.perspective.getNeighbourhoodProxy();
       const othersDids = await neighbourhood.otherAgents();
-      const profilePromises = [...othersDids, me.did].map(async (did) => getProfile(did));
+      const profilePromises = [...new Set([...othersDids, me.did])].map(async (did) => getProfile(did));
       const newProfiles = await Promise.all(profilePromises);
       this.members = newProfiles;
     }

--- a/views/kanban-view-simple/src/components/Board/Board.tsx
+++ b/views/kanban-view-simple/src/components/Board/Board.tsx
@@ -69,7 +69,7 @@ export default function Board({ perspective, channelId, agent, getProfile }: Boa
   async function getProfiles() {
     const others = await perspective.getNeighbourhoodProxy().otherAgents();
     const me = await agent.me();
-    const agentDids = [me.did, ...others];
+    const agentDids = [...new Set([...others, me.did])];
     // Set minimal profiles while loading full ones
     setAgentProfiles(agentDids.map((did) => ({ did }) as Profile));
     const profiles = await Promise.all(agentDids.map(getProfile));

--- a/views/kanban-view/src/components/Board/Board.tsx
+++ b/views/kanban-view/src/components/Board/Board.tsx
@@ -3,7 +3,7 @@ import { useModel } from '@coasys/ad4m-react-hooks';
 import { AgentClient } from '@coasys/ad4m/lib/src/agent/AgentClient';
 import { Profile } from '@coasys/flux-types';
 import { useEffect, useMemo } from 'preact/hooks';
-import { useState } from 'react';
+import { useState, Fragment } from 'react';
 import { DragDropContext, Draggable, Droppable } from 'react-beautiful-dnd';
 import Card from '../Card';
 import CardDetails from '../CardDetails';
@@ -38,7 +38,7 @@ export default function Board({ perspective, source, agent, getProfile }: BoardP
   async function getProfiles() {
     const others = await perspective.getNeighbourhoodProxy().otherAgents();
     const me = await agent.me();
-    const profiles = await Promise.all([me.did, ...others].map(getProfile));
+    const profiles = await Promise.all([...new Set([...others, me.did])].map(getProfile));
     setAgentProfiles(profiles);
   }
 

--- a/views/nillion-file-store/src/components/FileView.tsx
+++ b/views/nillion-file-store/src/components/FileView.tsx
@@ -142,7 +142,7 @@ export function FileView({ perspective, source, agent }: Props) {
         if (neighbourhood) {
           const others = await neighbourhood?.otherAgents();
           console.log('Got others:', others);
-          setOtherAgents([...others, me.did]);
+          setOtherAgents([...new Set([...others, me.did])]);
         }
       }
     };


### PR DESCRIPTION
Results from `neighbourhoodProxy.otherAgents()` function deduplicated across all Flux packages as a fallback fix for duplication which has now be resolved in Adam PR: [Duplicate agent fix #641](https://github.com/coasys/ad4m/pull/641)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate entries appearing in user lists across the application, improving performance and ensuring accurate display of team members and profiles.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->