### PR TITLE
Conversation subgroups ordered by timestamp

### DIFF
--- a/packages/api/src/conversation/index.ts
+++ b/packages/api/src/conversation/index.ts
@@ -254,12 +254,14 @@ export default class Conversation extends Ad4mModel {
       const surrealQuery = `
         SELECT
           out.uri AS baseExpression,
+          timestamp,
           fn::parse_literal(out->link[WHERE predicate = 'flux://has_name'][0].out.uri) AS name,
           fn::parse_literal(out->link[WHERE predicate = 'flux://has_summary'][0].out.uri) AS summary
         FROM link
         WHERE in.uri = '${this.baseExpression}'
           AND predicate = 'ad4m://has_child'
           AND out->link[WHERE predicate = 'flux://entry_type'][0].out.uri = 'flux://conversation_subgroup'
+        ORDER BY timestamp ASC
       `;
 
       const surrealResult = await this.perspective.querySurrealDB(surrealQuery);


### PR DESCRIPTION
Conversation subgroups now ordered by timestamp in surreal query

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Subgroup retrieval operations now include timestamp information in returned data and automatically sort results in ascending chronological order, ensuring consistent and deterministic result ordering. This improvement provides more predictable and reliable behavior when querying subgroup information through the API.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->