### PR TITLE
Fix/multi tab signalling coordination

### DIFF
--- a/app/src/composables/useSignallingService.ts
+++ b/app/src/composables/useSignallingService.ts
@@ -299,11 +299,12 @@ export function useSignallingService(neighbourhood: NeighbourhoodProxy): Signall
     // Keep the cleanup interval running — follower tabs still evaluate peer staleness
   }
 
-  // Register tab coordinator callbacks so leadership changes toggle broadcasting
-  tabCoordinator.onBecomeLeader(() => {
+  // Register tab coordinator callbacks so leadership changes toggle broadcasting.
+  // Keep the unsubscribe handles so stopSignalling can clean up.
+  const unsubBecomeLeader = tabCoordinator.onBecomeLeader(() => {
     if (signalling.value) startBroadcasting();
   });
-  tabCoordinator.onLoseLeadership(() => {
+  const unsubLoseLeadership = tabCoordinator.onLoseLeadership(() => {
     stopBroadcasting();
   });
 
@@ -327,6 +328,10 @@ export function useSignallingService(neighbourhood: NeighbourhoodProxy): Signall
   function stopSignalling(): void {
     // Remove the signal handler
     neighbourhood.removeSignalHandler(onSignal);
+
+    // Unsubscribe from tab coordinator to avoid leaking closures
+    unsubBecomeLeader();
+    unsubLoseLeadership();
 
     // Clear the intervals
     stopBroadcasting();

--- a/app/src/composables/useSignallingService.ts
+++ b/app/src/composables/useSignallingService.ts
@@ -299,14 +299,24 @@ export function useSignallingService(neighbourhood: NeighbourhoodProxy): Signall
     // Keep the cleanup interval running — follower tabs still evaluate peer staleness
   }
 
-  // Register tab coordinator callbacks so leadership changes toggle broadcasting.
-  // Keep the unsubscribe handles so stopSignalling can clean up.
-  const unsubBecomeLeader = tabCoordinator.onBecomeLeader(() => {
-    if (signalling.value) startBroadcasting();
-  });
-  const unsubLoseLeadership = tabCoordinator.onLoseLeadership(() => {
-    stopBroadcasting();
-  });
+  // Unsubscribe handles for leadership callbacks — stored at composable scope
+  // so stopSignalling can clean up and startSignalling can re-subscribe.
+  let unsubBecomeLeader: (() => void) | null = null;
+  let unsubLoseLeadership: (() => void) | null = null;
+
+  /** (Re-)subscribe to tab-coordinator leadership events. */
+  function subscribeLeadership(): void {
+    // Avoid double-subscribe: tear down any existing subscriptions first.
+    if (unsubBecomeLeader) unsubBecomeLeader();
+    if (unsubLoseLeadership) unsubLoseLeadership();
+
+    unsubBecomeLeader = tabCoordinator.onBecomeLeader(() => {
+      if (signalling.value) startBroadcasting();
+    });
+    unsubLoseLeadership = tabCoordinator.onLoseLeadership(() => {
+      stopBroadcasting();
+    });
+  }
 
   function startSignalling(): void {
     if (signalling.value) stopSignalling();
@@ -321,6 +331,9 @@ export function useSignallingService(neighbourhood: NeighbourhoodProxy): Signall
     // Start the cleanup interval on all tabs (evaluates agent staleness)
     cleanupInterval = setInterval(evaluateAgents, CLEANUP_INTERVAL);
 
+    // Subscribe (or re-subscribe) to leadership changes
+    subscribeLeadership();
+
     // Only the leader tab broadcasts heartbeats to the network
     if (tabCoordinator.isLeader.value) startBroadcasting();
   }
@@ -330,8 +343,14 @@ export function useSignallingService(neighbourhood: NeighbourhoodProxy): Signall
     neighbourhood.removeSignalHandler(onSignal);
 
     // Unsubscribe from tab coordinator to avoid leaking closures
-    unsubBecomeLeader();
-    unsubLoseLeadership();
+    if (unsubBecomeLeader) {
+      unsubBecomeLeader();
+      unsubBecomeLeader = null;
+    }
+    if (unsubLoseLeadership) {
+      unsubLoseLeadership();
+      unsubLoseLeadership = null;
+    }
 
     // Clear the intervals
     stopBroadcasting();

--- a/app/src/composables/useSignallingService.ts
+++ b/app/src/composables/useSignallingService.ts
@@ -5,6 +5,7 @@ import { Link, NeighbourhoodProxy, PerspectiveExpression } from '@coasys/ad4m';
 import { AgentData, AgentState, AgentStatus, ProcessingState, SignallingService } from '@coasys/flux-types';
 import { storeToRefs } from 'pinia';
 import { computed, ref, watch } from 'vue';
+import { useTabCoordinator } from './useTabCoordinator';
 
 export const HEARTBEAT_INTERVAL = 5000; // 5 seconds between heartbeats
 const CLEANUP_INTERVAL = 10000; // 10 seconds between evaluations
@@ -13,6 +14,7 @@ const MAX_AGE = 60000; // 60 seconds before "offline"
 const NEW_STATE = 'agent/new-state';
 
 export function useSignallingService(neighbourhood: NeighbourhoodProxy): SignallingService {
+  const tabCoordinator = useTabCoordinator();
   const appStore = useAppStore();
   const webrtcStore = useWebrtcStore();
   const mediaDevicesStore = useMediaDevicesStore();
@@ -221,6 +223,8 @@ export function useSignallingService(neighbourhood: NeighbourhoodProxy): Signall
 
   function broadcastState(target: string = ''): void {
     if (!signalling.value) return;
+    // Only the leader tab broadcasts to the network to prevent duplicate heartbeats
+    if (!tabCoordinator.isLeader.value) return;
 
     // Broadcast my state to the neighbourhood
     const newState = { source: JSON.stringify(myState.value), predicate: NEW_STATE, target };
@@ -278,6 +282,31 @@ export function useSignallingService(neighbourhood: NeighbourhoodProxy): Signall
     }, delay);
   }
 
+  // ── Leader-only broadcasting ──────────────────────────────────────────────
+  // These start/stop the heartbeat + cleanup timers that only the leader should run.
+  function startBroadcasting(): void {
+    if (!signalling.value) return;
+    broadcastState('first-broadcast');
+    scheduleNextHeartbeat(HEARTBEAT_INTERVAL);
+    if (!cleanupInterval) cleanupInterval = setInterval(evaluateAgents, CLEANUP_INTERVAL);
+  }
+
+  function stopBroadcasting(): void {
+    if (heartbeatTimeout) {
+      clearTimeout(heartbeatTimeout);
+      heartbeatTimeout = null;
+    }
+    // Keep the cleanup interval running — follower tabs still evaluate peer staleness
+  }
+
+  // Register tab coordinator callbacks so leadership changes toggle broadcasting
+  tabCoordinator.onBecomeLeader(() => {
+    if (signalling.value) startBroadcasting();
+  });
+  tabCoordinator.onLoseLeadership(() => {
+    stopBroadcasting();
+  });
+
   function startSignalling(): void {
     if (signalling.value) stopSignalling();
     signalling.value = true;
@@ -285,17 +314,14 @@ export function useSignallingService(neighbourhood: NeighbourhoodProxy): Signall
     // Add my agent state to the agents map
     agents.value[me.value.did] = myState.value;
 
-    // Add signal handler
+    // All tabs listen for signals so the UI stays up-to-date
     neighbourhood.addSignalHandler(onSignal);
 
-    // Send first broadcast
-    broadcastState('first-broadcast');
-
-    // Schedule first heartbeat
-    scheduleNextHeartbeat(HEARTBEAT_INTERVAL);
-
-    // Start the cleanup interval
+    // Start the cleanup interval on all tabs (evaluates agent staleness)
     cleanupInterval = setInterval(evaluateAgents, CLEANUP_INTERVAL);
+
+    // Only the leader tab broadcasts heartbeats to the network
+    if (tabCoordinator.isLeader.value) startBroadcasting();
   }
 
   function stopSignalling(): void {
@@ -303,6 +329,7 @@ export function useSignallingService(neighbourhood: NeighbourhoodProxy): Signall
     neighbourhood.removeSignalHandler(onSignal);
 
     // Clear the intervals
+    stopBroadcasting();
     if (cleanupInterval) {
       clearInterval(cleanupInterval);
       cleanupInterval = null;

--- a/app/src/composables/useTabCoordinator.ts
+++ b/app/src/composables/useTabCoordinator.ts
@@ -114,8 +114,11 @@ function createTabCoordinator() {
    * Attempt to claim leadership.  If `force` is true (used when joining a
    * call) we will claim even if another leader exists, unless that leader
    * is itself in a call.
+   *
+   * Returns a promise that resolves after a short grace period, giving
+   * the current leader time to respond with 'call-pinned' if it refuses.
    */
-  function claimLeadership(force = false): boolean {
+  async function claimLeadership(force = false): Promise<boolean> {
     if (isLeader.value) return true; // already leader
 
     // If we know the current leader is in a call, don't try unless forced
@@ -125,7 +128,13 @@ function createTabCoordinator() {
     // Optimistically become leader — if the existing leader refuses it will
     // send back a 'call-pinned' message and we'll revert.
     becomeLeader();
-    return true;
+
+    // Wait briefly for a potential 'call-pinned' rejection from the current
+    // leader. BroadcastChannel is async so we need this grace period.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    // If we lost leadership during the wait, the claim was rejected
+    return isLeader.value;
   }
 
   function resign() {
@@ -157,11 +166,10 @@ function createTabCoordinator() {
         break;
 
       case 'call-pinned':
-        // The existing leader refused our claim because it's in a call
-        if (isLeader.value && currentLeaderTabId !== tabId) {
-          // Revert our optimistic claim
-          loseLeadership();
-        }
+        // The existing leader refused our claim because it's in a call.
+        // Always revert our optimistic claim — msg.tabId is guaranteed to
+        // be a different tab (own messages are filtered at the top).
+        if (isLeader.value) loseLeadership();
         otherTabInCall.value = true;
         currentLeaderTabId = msg.tabId;
         resetLeaderTimeout();

--- a/app/src/composables/useTabCoordinator.ts
+++ b/app/src/composables/useTabCoordinator.ts
@@ -58,8 +58,8 @@ function createTabCoordinator() {
   let currentLeaderTabId: string | null = null;
 
   // Callbacks that consumers register (signalling start/stop)
-  const onBecomeLeader: Array<() => void> = [];
-  const onLoseLeadership: Array<() => void> = [];
+  const onBecomeLeaderCbs = new Set<() => void>();
+  const onLoseLeadershipCbs = new Set<() => void>();
 
   // ── Helpers ──────────────────────────────────────────────────────────────
   function post(msg: Omit<CoordinatorMessage, 'tabId' | 'timestamp'>) {
@@ -68,7 +68,7 @@ function createTabCoordinator() {
 
   function startLeaderHeartbeat() {
     stopLeaderHeartbeat();
-    leaderHeartbeatTimer = setInterval(() => post({ type: 'heartbeat' }), LEADER_HEARTBEAT_INTERVAL);
+    leaderHeartbeatTimer = setInterval(() => post({ type: 'heartbeat', inCall: _inCall }), LEADER_HEARTBEAT_INTERVAL);
   }
 
   function stopLeaderHeartbeat() {
@@ -100,14 +100,18 @@ function createTabCoordinator() {
     currentLeaderTabId = tabId;
     otherTabInCall.value = false;
     startLeaderHeartbeat();
-    onBecomeLeader.forEach((cb) => cb());
+    onBecomeLeaderCbs.forEach((cb) => {
+      cb();
+    });
   }
 
   function loseLeadership() {
     if (!isLeader.value) return;
     isLeader.value = false;
     stopLeaderHeartbeat();
-    onLoseLeadership.forEach((cb) => cb());
+    onLoseLeadershipCbs.forEach((cb) => {
+      cb();
+    });
   }
 
   /**
@@ -295,10 +299,20 @@ function createTabCoordinator() {
     setInCall,
     /** Request the leader tab to surface itself (window.focus) */
     requestLeaderFocus: () => post({ type: 'request-focus' }),
-    /** Register a callback for when this tab becomes the leader */
-    onBecomeLeader: (cb: () => void) => { onBecomeLeader.push(cb); },
-    /** Register a callback for when this tab loses leadership */
-    onLoseLeadership: (cb: () => void) => { onLoseLeadership.push(cb); },
+    /** Subscribe to leadership gained. Returns an unsubscribe function. */
+    onBecomeLeader: (cb: () => void) => {
+      onBecomeLeaderCbs.add(cb);
+      return () => {
+        onBecomeLeaderCbs.delete(cb);
+      };
+    },
+    /** Subscribe to leadership lost. Returns an unsubscribe function. */
+    onLoseLeadership: (cb: () => void) => {
+      onLoseLeadershipCbs.add(cb);
+      return () => {
+        onLoseLeadershipCbs.delete(cb);
+      };
+    },
     destroy,
   };
 }

--- a/app/src/composables/useTabCoordinator.ts
+++ b/app/src/composables/useTabCoordinator.ts
@@ -81,8 +81,13 @@ function createTabCoordinator() {
   function resetLeaderTimeout() {
     if (leaderTimeoutTimer) clearTimeout(leaderTimeoutTimer);
     leaderTimeoutTimer = setTimeout(() => {
-      // Leader appears dead — if we're visible, claim
-      if (document.visibilityState === 'visible') claimLeadership();
+      // Leader appears dead — if we're visible, claim.
+      // Clear stale otherTabInCall so claimLeadership isn't rejected by a
+      // guard that no longer applies (the leader that was in a call is gone).
+      if (document.visibilityState === 'visible') {
+        otherTabInCall.value = false;
+        claimLeadership();
+      }
     }, LEADER_TIMEOUT);
   }
 

--- a/app/src/composables/useTabCoordinator.ts
+++ b/app/src/composables/useTabCoordinator.ts
@@ -1,0 +1,296 @@
+/**
+ * Tab Coordinator — Focus-follows-leader pattern
+ *
+ * Ensures only one browser tab per origin runs the signalling heartbeat and
+ * WebRTC call logic.  Leadership silently follows user focus: whichever tab
+ * the user is looking at becomes the leader.  A tab that is actively in a
+ * call "pins" its leadership and refuses to yield until the call ends.
+ *
+ * Other tabs remain passive — they still receive signals so the UI stays
+ * up-to-date, but they do NOT broadcast heartbeats or state.
+ */
+import { ref, readonly } from 'vue';
+
+// ── Constants ────────────────────────────────────────────────────────────────
+const CHANNEL_NAME = 'flux-tab-coordinator';
+const LEADER_HEARTBEAT_INTERVAL = 5_000; // ms — leader pings all tabs
+const LEADER_TIMEOUT = 15_000; // ms — assume leader is dead if no ping
+
+// ── Message types ────────────────────────────────────────────────────────────
+interface CoordinatorMessage {
+  type: 'claim' | 'yield' | 'heartbeat' | 'call-pinned' | 'resign' | 'request-focus';
+  tabId: string;
+  timestamp: number;
+  /** When type === 'call-pinned', the leader tells the claimer it can't yield */
+  inCall?: boolean;
+}
+
+// ── Per-tab unique ID (survives soft reloads, not new tabs) ──────────────────
+function getTabId(): string {
+  let id = sessionStorage.getItem('flux-tab-id');
+  if (!id) {
+    id = crypto.randomUUID();
+    sessionStorage.setItem('flux-tab-id', id);
+  }
+  return id;
+}
+
+// ── Singleton ────────────────────────────────────────────────────────────────
+// The coordinator must be shared across all composable consumers in the same
+// tab, so we lazily initialise it once.
+
+let _instance: ReturnType<typeof createTabCoordinator> | null = null;
+
+export function useTabCoordinator() {
+  if (!_instance) _instance = createTabCoordinator();
+  return _instance;
+}
+
+// ── Factory ──────────────────────────────────────────────────────────────────
+function createTabCoordinator() {
+  const tabId = getTabId();
+  const isLeader = ref(false);
+  const otherTabInCall = ref(false); // true when another tab refused to yield because of an active call
+
+  let channel: BroadcastChannel | null = null;
+  let leaderHeartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  let leaderTimeoutTimer: ReturnType<typeof setTimeout> | null = null;
+  let currentLeaderTabId: string | null = null;
+
+  // Callbacks that consumers register (signalling start/stop)
+  const onBecomeLeader: Array<() => void> = [];
+  const onLoseLeadership: Array<() => void> = [];
+
+  // ── Helpers ──────────────────────────────────────────────────────────────
+  function post(msg: Omit<CoordinatorMessage, 'tabId' | 'timestamp'>) {
+    channel?.postMessage({ ...msg, tabId, timestamp: Date.now() } as CoordinatorMessage);
+  }
+
+  function startLeaderHeartbeat() {
+    stopLeaderHeartbeat();
+    leaderHeartbeatTimer = setInterval(() => post({ type: 'heartbeat' }), LEADER_HEARTBEAT_INTERVAL);
+  }
+
+  function stopLeaderHeartbeat() {
+    if (leaderHeartbeatTimer) {
+      clearInterval(leaderHeartbeatTimer);
+      leaderHeartbeatTimer = null;
+    }
+  }
+
+  function resetLeaderTimeout() {
+    if (leaderTimeoutTimer) clearTimeout(leaderTimeoutTimer);
+    leaderTimeoutTimer = setTimeout(() => {
+      // Leader appears dead — if we're visible, claim
+      if (document.visibilityState === 'visible') claimLeadership();
+    }, LEADER_TIMEOUT);
+  }
+
+  // ── Core state transitions ───────────────────────────────────────────────
+  /** Whether this tab is currently in a call (set externally by webrtcStore) */
+  let _inCall = false;
+
+  function setInCall(value: boolean) {
+    _inCall = value;
+  }
+
+  function becomeLeader() {
+    if (isLeader.value) return;
+    isLeader.value = true;
+    currentLeaderTabId = tabId;
+    otherTabInCall.value = false;
+    startLeaderHeartbeat();
+    onBecomeLeader.forEach((cb) => cb());
+  }
+
+  function loseLeadership() {
+    if (!isLeader.value) return;
+    isLeader.value = false;
+    stopLeaderHeartbeat();
+    onLoseLeadership.forEach((cb) => cb());
+  }
+
+  /**
+   * Attempt to claim leadership.  If `force` is true (used when joining a
+   * call) we will claim even if another leader exists, unless that leader
+   * is itself in a call.
+   */
+  function claimLeadership(force = false): boolean {
+    if (isLeader.value) return true; // already leader
+
+    // If we know the current leader is in a call, don't try unless forced
+    if (!force && otherTabInCall.value) return false;
+
+    post({ type: 'claim', inCall: _inCall });
+    // Optimistically become leader — if the existing leader refuses it will
+    // send back a 'call-pinned' message and we'll revert.
+    becomeLeader();
+    return true;
+  }
+
+  function resign() {
+    if (!isLeader.value) return;
+    post({ type: 'resign' });
+    loseLeadership();
+  }
+
+  // ── BroadcastChannel message handler ─────────────────────────────────────
+  function handleMessage(event: MessageEvent<CoordinatorMessage>) {
+    const msg = event.data;
+    if (!msg || msg.tabId === tabId) return; // ignore own messages
+
+    switch (msg.type) {
+      case 'claim':
+        // Another tab is claiming leadership
+        if (isLeader.value) {
+          if (_inCall) {
+            // We're in a call — refuse to yield
+            post({ type: 'call-pinned', inCall: true });
+          } else {
+            // Yield gracefully
+            loseLeadership();
+          }
+        }
+        // Track who the leader is now
+        currentLeaderTabId = msg.tabId;
+        resetLeaderTimeout();
+        break;
+
+      case 'call-pinned':
+        // The existing leader refused our claim because it's in a call
+        if (isLeader.value && currentLeaderTabId !== tabId) {
+          // Revert our optimistic claim
+          loseLeadership();
+        }
+        otherTabInCall.value = true;
+        currentLeaderTabId = msg.tabId;
+        resetLeaderTimeout();
+        break;
+
+      case 'heartbeat':
+        // The current leader is alive
+        currentLeaderTabId = msg.tabId;
+        if (isLeader.value && msg.tabId !== tabId) {
+          // Two leaders detected — the other one wins if we're not in a call
+          if (!_inCall) loseLeadership();
+        }
+        otherTabInCall.value = !!msg.inCall;
+        resetLeaderTimeout();
+        break;
+
+      case 'resign':
+        // The leader is leaving — if we're visible, claim
+        if (msg.tabId === currentLeaderTabId) {
+          currentLeaderTabId = null;
+          if (document.visibilityState === 'visible') claimLeadership();
+        }
+        break;
+
+      case 'yield':
+        // Explicit yield — same as resign for us
+        if (msg.tabId === currentLeaderTabId) {
+          currentLeaderTabId = null;
+          if (document.visibilityState === 'visible') claimLeadership();
+        }
+        break;
+
+      case 'request-focus':
+        // Another tab asked us (the leader) to surface — best effort
+        if (isLeader.value) {
+          try {
+            window.focus();
+          } catch {
+            // Browsers may block this
+          }
+        }
+        break;
+    }
+  }
+
+  // ── Visibility / focus listeners ─────────────────────────────────────────
+  function handleVisibilityChange() {
+    if (document.visibilityState === 'visible') {
+      // Tab became visible — try to claim leadership
+      claimLeadership();
+    }
+  }
+
+  function handleFocus() {
+    claimLeadership();
+  }
+
+  function handleBeforeUnload() {
+    resign();
+    // Synchronous channel post for unload
+    try {
+      channel?.postMessage({ type: 'resign', tabId, timestamp: Date.now() } as CoordinatorMessage);
+    } catch {
+      // Channel may already be closed
+    }
+  }
+
+  // ── Lifecycle ────────────────────────────────────────────────────────────
+  function init() {
+    channel = new BroadcastChannel(CHANNEL_NAME);
+    channel.onmessage = handleMessage;
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    window.addEventListener('focus', handleFocus);
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    // On startup: wait a short beat for any existing leader heartbeat.
+    // If none arrives, claim leadership.
+    leaderTimeoutTimer = setTimeout(() => {
+      if (!isLeader.value && !currentLeaderTabId) {
+        // No leader detected — we become leader
+        becomeLeader();
+        post({ type: 'claim', inCall: _inCall });
+      }
+    }, 1_000);
+
+    // If we're already visible (most common for first tab), claim immediately
+    // after a microtask so other tabs have a chance to respond.
+    if (document.visibilityState === 'visible') {
+      setTimeout(() => {
+        if (!currentLeaderTabId) {
+          becomeLeader();
+          post({ type: 'claim', inCall: _inCall });
+        }
+      }, 100);
+    }
+  }
+
+  function destroy() {
+    resign();
+    document.removeEventListener('visibilitychange', handleVisibilityChange);
+    window.removeEventListener('focus', handleFocus);
+    window.removeEventListener('beforeunload', handleBeforeUnload);
+    stopLeaderHeartbeat();
+    if (leaderTimeoutTimer) clearTimeout(leaderTimeoutTimer);
+    if (channel) {
+      channel.onmessage = null;
+      channel.close();
+      channel = null;
+    }
+    _instance = null;
+  }
+
+  // Auto-initialise
+  init();
+
+  return {
+    tabId,
+    isLeader: readonly(isLeader),
+    otherTabInCall: readonly(otherTabInCall),
+    claimLeadership,
+    resign,
+    setInCall,
+    /** Request the leader tab to surface itself (window.focus) */
+    requestLeaderFocus: () => post({ type: 'request-focus' }),
+    /** Register a callback for when this tab becomes the leader */
+    onBecomeLeader: (cb: () => void) => { onBecomeLeader.push(cb); },
+    /** Register a callback for when this tab loses leadership */
+    onLoseLeadership: (cb: () => void) => { onLoseLeadership.push(cb); },
+    destroy,
+  };
+}

--- a/app/src/stores/webrtcStore.ts
+++ b/app/src/stores/webrtcStore.ts
@@ -597,9 +597,9 @@ export const useWebrtcStore = defineStore(
 
       try {
         // Promote this tab to leader so it controls signalling & WebRTC.
-        // If another tab is already in a call the claim will be refused.
-        const claimed = tabCoordinator.claimLeadership(true);
-        if (!claimed || tabCoordinator.otherTabInCall.value) {
+        // claimLeadership waits briefly for a potential 'call-pinned' rejection.
+        const claimed = await tabCoordinator.claimLeadership(true);
+        if (!claimed) {
           appStore.showDangerToast({ message: 'You are already in a call in another tab.' });
           tabCoordinator.requestLeaderFocus();
           joiningCall.value = false;

--- a/app/src/stores/webrtcStore.ts
+++ b/app/src/stores/webrtcStore.ts
@@ -3,6 +3,7 @@ import kissWav from '@/assets/audio/kiss.wav';
 import pigWav from '@/assets/audio/pig.wav';
 import popWav from '@/assets/audio/pop.wav';
 import { HEARTBEAT_INTERVAL } from '@/composables/useSignallingService';
+import { useTabCoordinator } from '@/composables/useTabCoordinator';
 import { getCachedAgentProfile } from '@/utils/userProfileCache';
 import { PerspectiveExpression } from '@coasys/ad4m';
 import { AgentState, AgentStatus, CallHealth, Profile, RouteParams } from '@coasys/flux-types';
@@ -72,6 +73,8 @@ export const useWebrtcStore = defineStore(
     const { me } = storeToRefs(appStore);
     const { stream: localStream, mediaSettings } = storeToRefs(mediaDevicesStore);
     const { getCommunityService } = communityServiceStore;
+
+    const tabCoordinator = useTabCoordinator();
 
     const popSound = new Howl({ src: [popWav] });
     const guitarSound = new Howl({ src: [guitarWav] });
@@ -593,6 +596,16 @@ export const useWebrtcStore = defineStore(
       joiningCall.value = true;
 
       try {
+        // Promote this tab to leader so it controls signalling & WebRTC.
+        // If another tab is already in a call the claim will be refused.
+        const claimed = tabCoordinator.claimLeadership(true);
+        if (!claimed || tabCoordinator.otherTabInCall.value) {
+          appStore.showDangerToast({ message: 'You are already in a call in another tab.' });
+          tabCoordinator.requestLeaderFocus();
+          joiningCall.value = false;
+          return;
+        }
+
         // Update the call route
         callRoute.value = route.params;
 
@@ -641,6 +654,7 @@ export const useWebrtcStore = defineStore(
         // Reset state
         inCall.value = false;
         callRoute.value = {};
+        tabCoordinator.setInCall(false);
 
         // Exit fullscreen before closing the call window
         if (uiStore.callWindowFullscreen) {
@@ -768,6 +782,9 @@ export const useWebrtcStore = defineStore(
       },
       { immediate: true },
     );
+
+    // Keep the tab coordinator in sync with call state
+    watch(inCall, (nowInCall) => tabCoordinator.setInCall(nowInCall), { immediate: true });
 
     return {
       inCall,


### PR DESCRIPTION
# Fix: Multi-tab signalling coordination

## Problem

When a user opens Flux in multiple browser tabs, each tab independently runs its own signalling heartbeat and broadcasts its own agent state. This causes two issues:

1. **Avatar flickering** — each tab broadcasts a different `currentRoute` for the same DID, so remote peers see the agent's position oscillate between channels every heartbeat cycle.
2. **WebRTC connect/disconnect loop** — tabs broadcast conflicting `inCall` / `callRoute` values, causing remote peers to repeatedly create and destroy peer connections for the same agent.

The root cause is that every tab creates its own `Ad4mClient` (separate WebSocket), registers its own signal handler, and runs its own heartbeat timer — with zero cross-tab coordination.

## Solution

Introduces a **focus-follows-leader** tab coordination pattern using the `BroadcastChannel` API. Only one tab (the "leader") broadcasts heartbeats and state to the network. Leadership automatically follows user focus — whichever tab the user is looking at becomes the leader, with no manual interaction required.

### New file: `app/src/composables/useTabCoordinator.ts`

Singleton composable that manages tab leader election:

- **Automatic focus-based leadership** — on `focus` / `visibilitychange`, the active tab claims leadership and the previous leader yields silently.
- **Call pinning** — a tab that is in a WebRTC call refuses to yield leadership, preventing mid-call disruptions.
- **Crash recovery** — the leader sends heartbeats every 5s via `BroadcastChannel`. If no heartbeat arrives for 15s, visible follower tabs auto-claim.
- **Graceful resign** — `beforeunload` broadcasts a resign message so remaining tabs can claim immediately.
- **Async claim with grace period** — `claimLeadership()` waits 300ms for potential `call-pinned` rejections before confirming, avoiding race conditions.

### Modified: `app/src/composables/useSignallingService.ts`

- All tabs still register `onSignal` handlers and run the agent staleness evaluator (UI stays accurate everywhere).
- Only the leader tab runs the heartbeat timer and calls `broadcastState()`.
- `onBecomeLeader` / `onLoseLeadership` callbacks auto-toggle broadcasting when leadership changes.

### Modified: `app/src/stores/webrtcStore.ts`

- `joinRoom()` now force-claims leadership before joining. If the claim is rejected (another tab is in a call), it shows a toast: *"You are already in a call in another tab"* and requests the leader tab to surface via `window.focus()`.
- `leaveRoom()` resets the coordinator's `inCall` flag so other tabs can claim leadership again.
- A `watch(inCall)` keeps the coordinator in sync with the store's call state.

## How to test

1. Open Flux in two browser tabs, both on the same community.
2. Navigate to different channels in each tab — remote peers should only see your avatar in the channel of the **focused** tab.
3. Join a call from Tab A, then switch to Tab B and try to join the same call — you should see a toast and Tab A should be surfaced.
4. Leave the call in Tab A, then join from Tab B — should work normally.
5. Close Tab A while it's the leader — Tab B should automatically take over signalling within seconds.

## Files changed

| File | Change |
|------|--------|
| `app/src/composables/useTabCoordinator.ts` | **New** — tab coordinator composable |
| `app/src/composables/useSignallingService.ts` | Guard broadcasts behind leader check |
| `app/src/stores/webrtcStore.ts` | Guard call joining with leadership claim |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-tab leadership so only one tab broadcasts signaling; automatic leader election based on tab focus and in-call pinning.
  * Cross-tab synchronization keeps call state consistent and requests leader attention when needed (prevents duplicate broadcasts).

* **Bug Fixes**
  * Prevents duplicate network signaling across tabs and improves robustness when joining or leaving calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->