### PR TITLE
SFU integration: renegotiation client + iceServers passthrough

### DIFF
--- a/packages/webrtc/package.json
+++ b/packages/webrtc/package.json
@@ -6,7 +6,11 @@
   "license": "ISC",
   "type": "module",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "vitest": "^1.0.0",
+    "jsdom": "^24.0.0"
   },
   "main": "./src/index.ts",
   "module": "./src/index.ts",
@@ -17,7 +21,6 @@
   "keywords": [],
   "dependencies": {
     "@coasys/ad4m": "0.11.1",
-    "@coasys/flux-constants": "workspace:*",
     "simple-peer": "^9.11.1"
   },
   "publishConfig": {

--- a/packages/webrtc/src/SfuManager.test.ts
+++ b/packages/webrtc/src/SfuManager.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi } from "vitest";
+import { resolveTopology, SfuManager } from "./SfuManager";
+
+// Mock NeighbourhoodProxy
+function mockNeighbourhood(overrides: Partial<Record<string, any>> = {}) {
+  return {
+    sfuConfig: vi.fn().mockResolvedValue({
+      mode: "mesh",
+      designatedPeer: null,
+      sfuPeers: [],
+      fallback: "mesh",
+      maxMeshParticipants: 4,
+      maxParticipantsPerNode: null,
+      ...overrides.config,
+    }),
+    sfuPeers: vi.fn().mockResolvedValue(overrides.sfuPeers ?? []),
+    sfuPeer: vi.fn().mockResolvedValue(overrides.sfuPeer ?? null),
+    callJoin: vi.fn().mockResolvedValue(
+      overrides.callJoin ?? {
+        roomName: "test",
+        neighbourhoodUrl: "nh://test",
+        participantId: "P1",
+        sdpAnswer: "{}",
+        redirectTo: null,
+        streamMapping: [],
+      }
+    ),
+    callLeave: vi.fn().mockResolvedValue(true),
+    callSetQualityPreference: vi.fn().mockResolvedValue(true),
+  } as any;
+}
+
+describe("resolveTopology", () => {
+  it("returns mesh for mesh mode", async () => {
+    const neighbourhood = mockNeighbourhood({ config: { mode: "mesh" } });
+    const result = await resolveTopology(neighbourhood, "test://nh", 2);
+    expect(result.topology).toBe("mesh");
+    expect(result.sfuPeer).toBeNull();
+  });
+
+  it("returns cascaded for cascaded mode with multiple peers", async () => {
+    const neighbourhood = mockNeighbourhood({
+      config: { mode: "cascaded" },
+      sfuPeers: ["did:1", "did:2"],
+    });
+    const result = await resolveTopology(neighbourhood, "test://nh", 2);
+    expect(result.topology).toBe("cascaded");
+    expect(result.sfuPeer).toBe("did:1");
+  });
+
+  it("returns sfu for cascaded mode with single peer", async () => {
+    const neighbourhood = mockNeighbourhood({
+      config: { mode: "cascaded" },
+      sfuPeers: ["did:only"],
+    });
+    const result = await resolveTopology(neighbourhood, "test://nh", 2);
+    expect(result.topology).toBe("sfu");
+    expect(result.sfuPeer).toBe("did:only");
+  });
+
+  it("returns mesh for cascaded mode with no peers", async () => {
+    const neighbourhood = mockNeighbourhood({
+      config: { mode: "cascaded" },
+      sfuPeers: [],
+    });
+    const result = await resolveTopology(neighbourhood, "test://nh", 2);
+    expect(result.topology).toBe("mesh");
+    expect(result.sfuPeer).toBeNull();
+  });
+
+  it("returns sfu when sfuPeer available and participants > maxMesh", async () => {
+    const neighbourhood = mockNeighbourhood({
+      config: { mode: "designated", maxMeshParticipants: 2 },
+      sfuPeer: "did:sfu",
+    });
+    const result = await resolveTopology(neighbourhood, "test://nh", 3);
+    expect(result.topology).toBe("sfu");
+    expect(result.sfuPeer).toBe("did:sfu");
+  });
+
+  it("returns mesh when participants <= maxMesh even with sfuPeer", async () => {
+    const neighbourhood = mockNeighbourhood({
+      config: { mode: "designated", maxMeshParticipants: 4 },
+      sfuPeer: "did:sfu",
+    });
+    const result = await resolveTopology(neighbourhood, "test://nh", 4);
+    expect(result.topology).toBe("mesh");
+    expect(result.sfuPeer).toBe("did:sfu");
+  });
+
+  // ---- Bug 1 regression tests: config scoping / gateway mode ----
+
+  it("MUST_return_sfu_topology_when_gateway_mode_and_maxMesh_zero", async () => {
+    const neighbourhood = mockNeighbourhood({
+      config: { mode: "designated", maxMeshParticipants: 0 },
+      sfuPeer: "did:gateway-sfu",
+    });
+    const result = await resolveTopology(neighbourhood, "test://nh", 1);
+    expect(result.topology).toBe("sfu");
+    expect(result.sfuPeer).toBe("did:gateway-sfu");
+  });
+
+  it("MUST_return_cascaded_topology_for_cascaded_mode", async () => {
+    const neighbourhood = mockNeighbourhood({
+      config: { mode: "cascaded" },
+      sfuPeers: ["did:node1", "did:node2", "did:node3"],
+    });
+    const result = await resolveTopology(neighbourhood, "test://nh", 5);
+    expect(result.topology).toBe("cascaded");
+  });
+
+  it("MUST_force_sfu_when_maxMeshParticipants_is_zero_regardless_of_count", async () => {
+    const neighbourhood = mockNeighbourhood({
+      config: { mode: "designated", maxMeshParticipants: 0 },
+      sfuPeer: "did:sfu-node",
+    });
+    // Even with just 1 participant, 1 > 0 so SFU should be chosen
+    const result = await resolveTopology(neighbourhood, "test://nh", 1);
+    expect(result.topology).toBe("sfu");
+    expect(result.sfuPeer).toBe("did:sfu-node");
+  });
+
+  it("MUST_propagate_error_when_sfuConfig_throws", async () => {
+    const neighbourhood = mockNeighbourhood();
+    neighbourhood.sfuConfig.mockRejectedValue(new Error("network error"));
+    // resolveTopology doesn't catch internally — the caller (webrtcStore) catches and falls back to mesh.
+    await expect(resolveTopology(neighbourhood, "test://nh", 2)).rejects.toThrow("network error");
+  });
+});
+
+// ---- Bug 2 regression tests: topology mapping ----
+
+describe("topology mapping (Bug 2: config mode to SfuTopology)", () => {
+  it("MUST_map_gateway_mode_to_sfu_topology", () => {
+    // The fix in webrtcStore maps config.mode to SfuTopology:
+    // sfuMode === 'cascaded' ? 'cascaded' : 'sfu'
+    const sfuMode = "gateway";
+    const sfuTopologyForMode = sfuMode === "cascaded" ? "cascaded" : "sfu";
+    expect(sfuTopologyForMode).toBe("sfu");
+  });
+
+  it("MUST_map_cascaded_mode_to_cascaded_topology", () => {
+    const sfuMode = "cascaded";
+    const sfuTopologyForMode = sfuMode === "cascaded" ? "cascaded" : "sfu";
+    expect(sfuTopologyForMode).toBe("cascaded");
+  });
+
+  it("MUST_map_designated_mode_to_sfu_topology", () => {
+    const sfuMode = "designated";
+    const sfuTopologyForMode = sfuMode === "cascaded" ? "cascaded" : "sfu";
+    expect(sfuTopologyForMode).toBe("sfu");
+  });
+
+  it("MUST_NOT_pass_raw_config_mode_as_topology", () => {
+    // "gateway" is NOT a valid SfuTopology — it must be mapped to "sfu"
+    const validTopologies = ["sfu", "mesh", "cascaded"];
+    const sfuMode = "gateway";
+    const mapped = sfuMode === "cascaded" ? "cascaded" : "sfu";
+    expect(validTopologies).toContain(mapped);
+    expect(validTopologies).not.toContain(sfuMode);
+  });
+});
+
+describe("SfuManager", () => {
+  // ---- Bug 1 regression: constructor accepts agentDid ----
+
+  it("MUST_accept_agentDid_parameter_in_constructor", () => {
+    const neighbourhood = mockNeighbourhood();
+    const manager = new SfuManager(neighbourhood, "room1", "did:key:test-agent");
+    expect(manager).toBeDefined();
+    expect(manager.getState().roomId).toBe("room1");
+  });
+
+  it("MUST_accept_optional_neighbourhoodUrl_and_iceConfig", () => {
+    const neighbourhood = mockNeighbourhood();
+    const manager = new SfuManager(neighbourhood, "room1", "did:key:agent", "nh://test", {
+      stun: ["stun:stun.example.com:3478"],
+      turn: [{ urls: "turn:turn.example.com", username: "user", credential: "pass" }],
+    });
+    expect(manager).toBeDefined();
+  });
+
+  it("selectNode picks lowest load", () => {
+    const neighbourhood = mockNeighbourhood();
+    const manager = new SfuManager(neighbourhood, "room1", "did:key:agent");
+    const nodes = [
+      { did: "a", participantCount: 5, capacityHint: 10 },
+      { did: "b", participantCount: 2, capacityHint: 10 },
+      { did: "c", participantCount: 8, capacityHint: 10 },
+    ];
+    const selected = (manager as any).selectNode(nodes);
+    expect(selected.did).toBe("b");
+  });
+
+  it("setQualityPreference calls neighbourhood API", async () => {
+    const neighbourhood = mockNeighbourhood();
+    const manager = new SfuManager(neighbourhood, "room1", "did:key:agent");
+    (manager as any).state.participantId = "P1";
+    await manager.setQualityPreference("low");
+    expect(neighbourhood.callSetQualityPreference).toHaveBeenCalledWith("", "room1", "low");
+  });
+
+  it("leave calls callLeave and clears state", async () => {
+    const neighbourhood = mockNeighbourhood();
+    const manager = new SfuManager(neighbourhood, "room1", "did:key:agent");
+    (manager as any).state.participantId = "P1";
+    (manager as any).state.participants.set("stream1", {
+      did: "did:1",
+      stream: {} as MediaStream,
+      hasAudio: true,
+      hasVideo: false,
+      isActiveSpeaker: false,
+    });
+
+    await manager.leave();
+    expect(neighbourhood.callLeave).toHaveBeenCalledWith("", "room1");
+    expect((manager as any).state.participants.size).toBe(0);
+    expect((manager as any).state.participantId).toBeNull();
+  });
+
+  it("events can be registered and emitted", () => {
+    const neighbourhood = mockNeighbourhood();
+    const manager = new SfuManager(neighbourhood, "room1", "did:key:agent");
+    const cb = vi.fn();
+    manager.on("topology-changed", cb);
+    (manager as any).emit("topology-changed", "mesh");
+    expect(cb).toHaveBeenCalledWith("mesh");
+  });
+});

--- a/packages/webrtc/src/SfuManager.test.ts
+++ b/packages/webrtc/src/SfuManager.test.ts
@@ -27,6 +27,8 @@ function mockNeighbourhood(overrides: Partial<Record<string, any>> = {}) {
     ),
     callLeave: vi.fn().mockResolvedValue(true),
     callSetQualityPreference: vi.fn().mockResolvedValue(true),
+    callAnswerServerOffer: vi.fn().mockResolvedValue(true),
+    subscribeCallRenegotiationOffer: vi.fn().mockReturnValue(() => {}),
   } as any;
 }
 
@@ -225,5 +227,26 @@ describe("SfuManager", () => {
     manager.on("topology-changed", cb);
     (manager as any).emit("topology-changed", "mesh");
     expect(cb).toHaveBeenCalledWith("mesh");
+  });
+
+  it("cascade failover stops after exhausting nodes", () => {
+    const neighbourhood = mockNeighbourhood();
+    const manager = new SfuManager(neighbourhood, "room1", "did:key:agent");
+    (manager as any).state.topology = "cascaded";
+    (manager as any).state.cascadeNodes = [
+      { did: "a", participantCount: 5, capacityHint: 10 },
+    ];
+    (manager as any).state.connectedNodeDid = "a";
+
+    const errorCb = vi.fn();
+    manager.on("error", errorCb);
+
+    // Simulate multiple failover attempts
+    for (let i = 0; i < 5; i++) {
+      (manager as any).handleCascadeFailover();
+    }
+
+    // Should have emitted error after exhausting nodes
+    expect(errorCb).toHaveBeenCalled();
   });
 });

--- a/packages/webrtc/src/SfuManager.ts
+++ b/packages/webrtc/src/SfuManager.ts
@@ -131,6 +131,9 @@ export class SfuManager {
   private callbacks: Map<SfuEvent, SfuEventCallback[]> = new Map();
   private iceServers: RTCIceServer[];
   private streamToParticipant: Map<string, string> = new Map();
+  /** Mid-to-DID mapping from server renegotiation offers — the reliable
+   *  correlation path (arrival-order trackDidIndex serves as fallback). */
+  private midToParticipant: Map<string, string> = new Map();
   /** Index into knownParticipantDids for correlating tracks to DIDs */
   private trackDidIndex: number = 0;
   /**
@@ -305,10 +308,18 @@ export class SfuManager {
         (p) => p.stream.id === stream.id
       );
 
-      // Resolve participant DID: try stream mapping first, then known DIDs by order, then fallback
-      let participantDid = this.streamToParticipant.get(stream.id);
+      // Resolve participant DID via three paths (most reliable first):
+      // 1. Mid-based lookup from server track_mapping (deterministic)
+      // 2. Stream-id cache from a prior ontrack for the same stream
+      // 3. Arrival-order index into knownParticipantDids (fragile fallback)
+      let participantDid: string | undefined;
+      const mid = event.transceiver?.mid;
+      if (mid) {
+        participantDid = this.midToParticipant.get(mid);
+        if (participantDid) this.streamToParticipant.set(stream.id, participantDid);
+      }
+      if (!participantDid) participantDid = this.streamToParticipant.get(stream.id);
       if (!participantDid && this.state.knownParticipantDids.length > 0 && this.trackDidIndex < this.state.knownParticipantDids.length) {
-        // Correlate by track arrival order matching the DID list
         participantDid = this.state.knownParticipantDids[this.trackDidIndex];
         this.streamToParticipant.set(stream.id, participantDid);
         this.trackDidIndex++;
@@ -395,11 +406,18 @@ export class SfuManager {
         neighbourhoodUrl: string
         roomName: string
         sdpOffer: string
+        trackMapping?: { mid: string; agentDid: string; mediaKind: string }[]
       }) => {
-        // Double-check filtering — defensive against any future
-        // events-WS fanout regression.
         if (event.neighbourhoodUrl !== this.neighbourhoodUrl) return
         if (event.roomName !== this.roomId) return
+
+        // Populate mid-to-DID attribution before applying the SDP —
+        // ontrack fires synchronously during setRemoteDescription.
+        if (event.trackMapping) {
+          for (const entry of event.trackMapping) {
+            this.midToParticipant.set(entry.mid, entry.agentDid)
+          }
+        }
 
         console.info(`SFU: received renegotiation offer for ${event.roomName}`)
         const currentPc = this.state.peerConnection
@@ -465,5 +483,6 @@ export class SfuManager {
     try { await this.leave(); } catch (e) { console.error("Error during SFU destroy:", e); }
     this.callbacks.clear();
     this.streamToParticipant.clear();
+    this.midToParticipant.clear();
   }
 }

--- a/packages/webrtc/src/SfuManager.ts
+++ b/packages/webrtc/src/SfuManager.ts
@@ -134,7 +134,14 @@ export class SfuManager {
   /** Index into knownParticipantDids for correlating tracks to DIDs */
   private trackDidIndex: number = 0;
 
-  constructor(neighbourhood: any, roomId: string, agentDid: string, neighbourhoodUrl?: string, iceConfig?: SfuIceConfig) {
+  constructor(
+    neighbourhood: any,
+    roomId: string,
+    agentDid: string,
+    neighbourhoodUrl?: string,
+    iceConfig?: SfuIceConfig,
+    sfuConfig?: SfuConfig,
+  ) {
     this.neighbourhood = neighbourhood;
     this.neighbourhoodUrl = neighbourhoodUrl || '';
     this.roomId = roomId;
@@ -152,16 +159,30 @@ export class SfuManager {
       knownParticipantDids: [],
     };
 
-    // Build ICE servers from config or use defaults
-    const servers: RTCIceServer[] = [];
-    if (iceConfig?.stun) {
-      for (const url of iceConfig.stun) {
-        servers.push({ urls: url });
+    // Resolution order for ICE servers:
+    //   1. `sfuConfig.iceServers` — authoritative when set on the
+    //      neighbourhood's SfuConfig.  Production path: the host app
+    //      rotates TURN creds server-side and every peer picks them up
+    //      without a redeploy.
+    //   2. `iceConfig` parameter — legacy override used by tests.
+    //   3. `DEFAULT_ICE_SERVERS` — public STUN fallback.
+    let servers: RTCIceServer[] = [];
+    if (sfuConfig?.iceServers && sfuConfig.iceServers.length > 0) {
+      servers = sfuConfig.iceServers.map((s) => ({
+        urls: s.urls,
+        username: s.username,
+        credential: s.credential,
+      }));
+    } else if (iceConfig) {
+      if (iceConfig.stun) {
+        for (const url of iceConfig.stun) {
+          servers.push({ urls: url });
+        }
       }
-    }
-    if (iceConfig?.turn) {
-      for (const t of iceConfig.turn) {
-        servers.push({ urls: t.urls, username: t.username, credential: t.credential });
+      if (iceConfig.turn) {
+        for (const t of iceConfig.turn) {
+          servers.push({ urls: t.urls, username: t.username, credential: t.credential });
+        }
       }
     }
     this.iceServers = servers.length > 0 ? servers : DEFAULT_ICE_SERVERS;

--- a/packages/webrtc/src/SfuManager.ts
+++ b/packages/webrtc/src/SfuManager.ts
@@ -18,6 +18,24 @@ import type {
   CallSessionInfo as CallSession,
 } from "@coasys/ad4m";
 
+/** Minimal interface for the neighbourhood proxy methods used by SfuManager. */
+export interface SfuNeighbourhoodApi {
+  callJoin(neighbourhoodUrl: string, roomName: string, sdpOffer: string): Promise<CallSession>;
+  callLeave(neighbourhoodUrl: string, roomName: string): Promise<boolean>;
+  callSetQualityPreference(neighbourhoodUrl: string, roomName: string, preference: string): Promise<boolean>;
+  callAnswerServerOffer(neighbourhoodUrl: string, roomName: string, sdpAnswer: string): Promise<boolean>;
+  subscribeCallRenegotiationOffer(
+    targetDid: string,
+    callback: (event: {
+      targetDid: string;
+      neighbourhoodUrl: string;
+      roomName: string;
+      sdpOffer: string;
+      trackMapping?: { mid: string; agentDid: string; mediaKind: string }[];
+    }) => void,
+  ): () => void;
+}
+
 export type SfuTopology = "sfu" | "mesh" | "cascaded";
 
 export interface SfuNodeState {
@@ -123,7 +141,7 @@ export async function resolveTopology(
  * SFU call manager. Handles WebRTC connection to the SFU server via the executor's GraphQL API.
  */
 export class SfuManager {
-  private neighbourhood: any; // NeighbourhoodClient or NeighbourhoodProxy
+  private neighbourhood: SfuNeighbourhoodApi;
   private neighbourhoodUrl: string; // URL for NeighbourhoodClient calls
   private roomId: string;
   private agentDid: string;
@@ -131,6 +149,7 @@ export class SfuManager {
   private callbacks: Map<SfuEvent, SfuEventCallback[]> = new Map();
   private iceServers: RTCIceServer[];
   private streamToParticipant: Map<string, string> = new Map();
+  private failoverAttempts: number = 0;
   /** Mid-to-DID mapping from server renegotiation offers — the reliable
    *  correlation path (arrival-order trackDidIndex serves as fallback). */
   private midToParticipant: Map<string, string> = new Map();
@@ -144,7 +163,7 @@ export class SfuManager {
   private renegotiationUnsubscribe: (() => void) | null = null;
 
   constructor(
-    neighbourhood: any,
+    neighbourhood: SfuNeighbourhoodApi,
     roomId: string,
     agentDid: string,
     neighbourhoodUrl?: string,
@@ -208,6 +227,14 @@ export class SfuManager {
   /** Handle SFU node disconnection in cascaded mode — reconnect to another node. */
   private async handleCascadeFailover(): Promise<void> {
     if (this.state.topology !== "cascaded") return;
+
+    this.failoverAttempts++;
+    const maxAttempts = Math.max(this.state.cascadeNodes.length, 3);
+    if (this.failoverAttempts >= maxAttempts) {
+      console.error("Cascade failover exhausted — no healthy nodes");
+      this.emit("error", new Error("Cascade failover exhausted — no healthy nodes"));
+      return;
+    }
 
     const availableNodes = this.state.cascadeNodes.filter(
       n => n.did !== this.state.connectedNodeDid
@@ -392,6 +419,7 @@ export class SfuManager {
 
     const answer = JSON.parse(session.sdpAnswer);
     await pc.setRemoteDescription(new RTCSessionDescription(answer));
+    this.failoverAttempts = 0;
 
     // Subscribe to server-initiated renegotiation offers — the SFU
     // pushes a fresh SDP offer whenever its outbound track set
@@ -460,6 +488,10 @@ export class SfuManager {
     }
     this.state.participants.clear();
     this.state.participantId = null;
+    this.midToParticipant.clear();
+    this.streamToParticipant.clear();
+    this.trackDidIndex = 0;
+    this.state.knownParticipantDids = [];
   }
 
   async setQualityPreference(preference: QualityPreference): Promise<void> {

--- a/packages/webrtc/src/SfuManager.ts
+++ b/packages/webrtc/src/SfuManager.ts
@@ -133,6 +133,12 @@ export class SfuManager {
   private streamToParticipant: Map<string, string> = new Map();
   /** Index into knownParticipantDids for correlating tracks to DIDs */
   private trackDidIndex: number = 0;
+  /**
+   * Unsubscribe handle for the server-pushed renegotiation events_ws
+   * subscription.  Set in `join` after `subscribeCallRenegotiationOffer`,
+   * cleared in `leave` so we don't leak listeners across room cycles.
+   */
+  private renegotiationUnsubscribe: (() => void) | null = null;
 
   constructor(
     neighbourhood: any,
@@ -376,30 +382,56 @@ export class SfuManager {
     const answer = JSON.parse(session.sdpAnswer);
     await pc.setRemoteDescription(new RTCSessionDescription(answer));
 
-    // Subscribe to server-initiated renegotiation offers (for new peers joining)
-    this.neighbourhood.subscribeCallRenegotiationOffer(this.agentDid, async (event: { reason: string; sdpOffer: string; roomId: string }) => {
-      console.info(`SFU: received renegotiation offer (reason: ${event.reason})`);
-      const currentPc = this.state.peerConnection;
-      if (!currentPc) {
-        console.warn("SFU: no peer connection for renegotiation");
-        return;
-      }
-      try {
-        const offerSdp = JSON.parse(event.sdpOffer);
-        await currentPc.setRemoteDescription(new RTCSessionDescription(offerSdp));
-        const renegAnswer = await currentPc.createAnswer();
-        await currentPc.setLocalDescription(renegAnswer);
-        const answerJson = JSON.stringify(currentPc.localDescription);
-        await this.neighbourhood.callAnswerServerOffer(this.neighbourhoodUrl, event.roomId, answerJson);
-        console.info("SFU: renegotiation answer sent successfully");
-      } catch (err) {
-        console.error("SFU: renegotiation failed:", err);
-        this.emit("error", err);
-      }
-    });
+    // Subscribe to server-initiated renegotiation offers — the SFU
+    // pushes a fresh SDP offer whenever its outbound track set
+    // changes for our DID (e.g. another peer joined the room).  We
+    // apply the offer, generate an answer, and post it back via
+    // `sfu.callAnswerServerOffer`.  The payload shape is defined by
+    // `crate::sfu::types::SfuCallRenegotiationOffer` (camelCase).
+    this.renegotiationUnsubscribe = this.neighbourhood.subscribeCallRenegotiationOffer(
+      this.agentDid,
+      async (event: {
+        targetDid: string
+        neighbourhoodUrl: string
+        roomName: string
+        sdpOffer: string
+      }) => {
+        // Double-check filtering — defensive against any future
+        // events-WS fanout regression.
+        if (event.neighbourhoodUrl !== this.neighbourhoodUrl) return
+        if (event.roomName !== this.roomId) return
+
+        console.info(`SFU: received renegotiation offer for ${event.roomName}`)
+        const currentPc = this.state.peerConnection
+        if (!currentPc) {
+          console.warn("SFU: no peer connection for renegotiation")
+          return
+        }
+        try {
+          const offerSdp = JSON.parse(event.sdpOffer)
+          await currentPc.setRemoteDescription(new RTCSessionDescription(offerSdp))
+          const renegAnswer = await currentPc.createAnswer()
+          await currentPc.setLocalDescription(renegAnswer)
+          const answerJson = JSON.stringify(currentPc.localDescription)
+          await this.neighbourhood.callAnswerServerOffer(
+            this.neighbourhoodUrl,
+            event.roomName,
+            answerJson,
+          )
+          console.info("SFU: renegotiation answer sent successfully")
+        } catch (err) {
+          console.error("SFU: renegotiation failed:", err)
+          this.emit("error", err)
+        }
+      },
+    )
   }
 
   async leave(): Promise<void> {
+    if (this.renegotiationUnsubscribe) {
+      try { this.renegotiationUnsubscribe(); } catch { /* swallow */ }
+      this.renegotiationUnsubscribe = null;
+    }
     if (this.state.peerConnection) {
       this.state.peerConnection.close();
       this.state.peerConnection = null;

--- a/packages/webrtc/src/SfuManager.ts
+++ b/packages/webrtc/src/SfuManager.ts
@@ -1,0 +1,416 @@
+/**
+ * SFU (Selective Forwarding Unit) manager for WebRTC calls.
+ *
+ * When the SFU is available for a neighbourhood, each peer connects once to the SFU
+ * instead of maintaining N-1 direct connections. The SFU forwards streams selectively.
+ *
+ * Falls back to mesh (WebRTCManager) when:
+ * - SFU mode is "mesh" (default)
+ * - SFU peer is unavailable
+ * - Participant count is ≤ maxMeshParticipants
+ */
+
+import { NeighbourhoodProxy } from "@coasys/ad4m";
+// Forward-port note: types live on the top-level @coasys/ad4m export now
+// (was deep-imported from NeighbourhoodClient pre WS-RPC migration).
+import type {
+  SfuConfig,
+  CallSessionInfo as CallSession,
+} from "@coasys/ad4m";
+
+export type SfuTopology = "sfu" | "mesh" | "cascaded";
+
+export interface SfuNodeState {
+  did: string;
+  participantCount: number;
+  capacityHint: number;
+}
+export type QualityPreference = "auto" | "high" | "medium" | "low";
+
+/** ICE server configuration for SFU peer connections. */
+export interface SfuIceConfig {
+  stun?: string[];
+  turn?: { urls: string; username: string; credential: string }[];
+}
+
+/** Default ICE servers — can be overridden via SfuManager constructor. */
+const DEFAULT_ICE_SERVERS: RTCIceServer[] = [
+  { urls: "stun:stun.l.google.com:19302" },
+];
+
+/** Timeout for ICE gathering (ms). */
+const ICE_GATHERING_TIMEOUT_MS = 8000;
+
+export interface SfuCallState {
+  topology: SfuTopology;
+  roomId: string;
+  participantId: string | null;
+  sfuPeerDid: string | null;
+  participants: Map<string, SfuParticipantState>;
+  localStream: MediaStream | null;
+  peerConnection: RTCPeerConnection | null;
+  cascadeNodes: SfuNodeState[];
+  connectedNodeDid: string | null;
+  /** DIDs of participants already in the room at join time */
+  knownParticipantDids: string[];
+}
+
+export interface SfuParticipantState {
+  did: string;
+  stream: MediaStream;
+  hasAudio: boolean;
+  hasVideo: boolean;
+  isActiveSpeaker: boolean;
+}
+
+export type SfuEvent =
+  | "topology-changed"
+  | "participant-joined"
+  | "participant-left"
+  | "active-speaker"
+  | "stream-added"
+  | "stream-removed"
+  | "error";
+
+export type SfuEventCallback = (...args: any[]) => void;
+
+/**
+ * Determines the optimal call topology based on SFU config and availability.
+ */
+export async function resolveTopology(
+  neighbourhood: NeighbourhoodProxy,
+  neighbourhoodUrl: string,
+  participantCount: number
+): Promise<{ topology: SfuTopology; sfuPeer: string | null; config: SfuConfig }> {
+  const config = await neighbourhood.sfuConfig(neighbourhoodUrl);
+
+  if (config.mode === "cascaded") {
+    // In cascaded mode, query for available SFU nodes
+    const sfuPeers: string[] = await neighbourhood.sfuPeers(neighbourhoodUrl);
+    if (sfuPeers.length > 1) {
+      return { topology: "cascaded" as SfuTopology, sfuPeer: sfuPeers[0], config };
+    }
+    if (sfuPeers.length === 1) {
+      return { topology: "sfu", sfuPeer: sfuPeers[0], config };
+    }
+    return { topology: "mesh", sfuPeer: null, config };
+  }
+
+  if (config.mode === "mesh") {
+    return { topology: "mesh", sfuPeer: null, config };
+  }
+
+  const sfuPeer = await neighbourhood.sfuPeer(neighbourhoodUrl);
+
+  if (!sfuPeer) {
+    if (participantCount <= config.maxMeshParticipants) {
+      return { topology: "mesh", sfuPeer: null, config };
+    }
+    console.warn(
+      `SFU peer unavailable and ${participantCount} participants exceeds mesh limit (${config.maxMeshParticipants}). Attempting mesh anyway.`
+    );
+    return { topology: "mesh", sfuPeer: null, config };
+  }
+
+  if (participantCount <= config.maxMeshParticipants) {
+    return { topology: "mesh", sfuPeer, config };
+  }
+
+  return { topology: "sfu", sfuPeer, config };
+}
+
+/**
+ * SFU call manager. Handles WebRTC connection to the SFU server via the executor's GraphQL API.
+ */
+export class SfuManager {
+  private neighbourhood: any; // NeighbourhoodClient or NeighbourhoodProxy
+  private neighbourhoodUrl: string; // URL for NeighbourhoodClient calls
+  private roomId: string;
+  private agentDid: string;
+  private state: SfuCallState;
+  private callbacks: Map<SfuEvent, SfuEventCallback[]> = new Map();
+  private iceServers: RTCIceServer[];
+  private streamToParticipant: Map<string, string> = new Map();
+  /** Index into knownParticipantDids for correlating tracks to DIDs */
+  private trackDidIndex: number = 0;
+
+  constructor(neighbourhood: any, roomId: string, agentDid: string, neighbourhoodUrl?: string, iceConfig?: SfuIceConfig) {
+    this.neighbourhood = neighbourhood;
+    this.neighbourhoodUrl = neighbourhoodUrl || '';
+    this.roomId = roomId;
+    this.agentDid = agentDid;
+    this.state = {
+      topology: "sfu",
+      roomId,
+      participantId: null,
+      sfuPeerDid: null,
+      participants: new Map(),
+      localStream: null,
+      peerConnection: null,
+      cascadeNodes: [],
+      connectedNodeDid: null,
+      knownParticipantDids: [],
+    };
+
+    // Build ICE servers from config or use defaults
+    const servers: RTCIceServer[] = [];
+    if (iceConfig?.stun) {
+      for (const url of iceConfig.stun) {
+        servers.push({ urls: url });
+      }
+    }
+    if (iceConfig?.turn) {
+      for (const t of iceConfig.turn) {
+        servers.push({ urls: t.urls, username: t.username, credential: t.credential });
+      }
+    }
+    this.iceServers = servers.length > 0 ? servers : DEFAULT_ICE_SERVERS;
+  }
+
+  /** Select the least-loaded SFU node from the cascade. */
+  private selectNode(nodes: SfuNodeState[]): SfuNodeState | null {
+    if (nodes.length === 0) return null;
+    return nodes.reduce((best, n) =>
+      n.participantCount < best.participantCount ? n : best
+    );
+  }
+
+  /** Handle SFU node disconnection in cascaded mode — reconnect to another node. */
+  private async handleCascadeFailover(): Promise<void> {
+    if (this.state.topology !== "cascaded") return;
+
+    const availableNodes = this.state.cascadeNodes.filter(
+      n => n.did !== this.state.connectedNodeDid
+    );
+    const nextNode = this.selectNode(availableNodes);
+    if (!nextNode) {
+      console.warn("No cascade nodes available for failover, falling back to mesh");
+      this.emit("topology-changed", "mesh");
+      return;
+    }
+
+    console.info(`SFU cascade failover: reconnecting to node ${nextNode.did}`);
+    this.state.connectedNodeDid = nextNode.did;
+    this.state.sfuPeerDid = nextNode.did;
+
+    // Reconnect
+    if (this.state.localStream) {
+      try {
+        if (this.state.peerConnection) {
+          this.state.peerConnection.close();
+          this.state.peerConnection = null;
+        }
+        await this.join(this.state.localStream);
+      } catch (e) {
+        console.error("Cascade failover failed:", e);
+        this.emit("error", e);
+      }
+    }
+  }
+
+  on(event: SfuEvent, callback: SfuEventCallback): void {
+    if (!this.callbacks.has(event)) {
+      this.callbacks.set(event, []);
+    }
+    this.callbacks.get(event)!.push(callback);
+  }
+
+  off(event: SfuEvent, callback?: SfuEventCallback): void {
+    if (!callback) {
+      this.callbacks.delete(event);
+      return;
+    }
+    const cbs = this.callbacks.get(event);
+    if (cbs) {
+      const idx = cbs.indexOf(callback);
+      if (idx !== -1) cbs.splice(idx, 1);
+      if (cbs.length === 0) this.callbacks.delete(event);
+    }
+  }
+
+  private emit(event: SfuEvent, ...args: any[]): void {
+    const cbs = this.callbacks.get(event);
+    if (cbs) {
+      for (const cb of cbs) {
+        try { cb(...args); } catch (e) { console.error(`SFU event handler error (${event}):`, e); }
+      }
+    }
+  }
+
+  /**
+   * Join the SFU call with simulcast support.
+   */
+  async join(localStream: MediaStream): Promise<void> {
+    this.state.localStream = localStream;
+
+    const pc = new RTCPeerConnection({ iceServers: this.iceServers });
+    this.state.peerConnection = pc;
+
+    // ICE connection state monitoring for cascade failover
+    pc.oniceconnectionstatechange = () => {
+      if (pc.iceConnectionState === "failed" || pc.iceConnectionState === "disconnected") {
+        this.handleCascadeFailover();
+      }
+    };
+
+    // Add local tracks — video with simulcast encodings (3 layers)
+    for (const track of localStream.getTracks()) {
+      if (track.kind === "video") {
+        pc.addTransceiver(track, {
+          direction: "sendrecv",
+          sendEncodings: [
+            { rid: "high", maxBitrate: 1500000 },
+            { rid: "medium", maxBitrate: 500000, scaleResolutionDownBy: 2 },
+            { rid: "low", maxBitrate: 150000, scaleResolutionDownBy: 4 },
+          ],
+        });
+      } else {
+        pc.addTrack(track, localStream);
+      }
+    }
+
+    // Handle incoming tracks from SFU
+    pc.ontrack = (event: RTCTrackEvent) => {
+      const stream = event.streams[0];
+      if (!stream) return;
+
+      const existing = Array.from(this.state.participants.values()).find(
+        (p) => p.stream.id === stream.id
+      );
+
+      // Resolve participant DID: try stream mapping first, then known DIDs by order, then fallback
+      let participantDid = this.streamToParticipant.get(stream.id);
+      if (!participantDid && this.state.knownParticipantDids.length > 0 && this.trackDidIndex < this.state.knownParticipantDids.length) {
+        // Correlate by track arrival order matching the DID list
+        participantDid = this.state.knownParticipantDids[this.trackDidIndex];
+        this.streamToParticipant.set(stream.id, participantDid);
+        this.trackDidIndex++;
+      }
+      if (!participantDid) participantDid = stream.id;
+
+      if (existing) {
+        existing.hasAudio = existing.hasAudio || event.track.kind === "audio";
+        existing.hasVideo = existing.hasVideo || event.track.kind === "video";
+      } else {
+        const participant: SfuParticipantState = {
+          did: participantDid,
+          stream,
+          hasAudio: event.track.kind === "audio",
+          hasVideo: event.track.kind === "video",
+          isActiveSpeaker: false,
+        };
+        this.state.participants.set(stream.id, participant);
+        this.emit("participant-joined", participant);
+      }
+
+      this.emit("stream-added", stream, event.track);
+      event.track.onended = () => this.emit("stream-removed", stream, event.track);
+    };
+
+    // Create and send offer to SFU
+    const offer = await pc.createOffer();
+    await pc.setLocalDescription(offer);
+
+    // Wait for ICE gathering with timeout
+    await new Promise<void>((resolve) => {
+      if (pc.iceGatheringState === "complete") return resolve();
+      const timeout = setTimeout(() => {
+        pc.onicegatheringstatechange = null;
+        console.warn("SFU: ICE gathering timed out, proceeding with partial candidates");
+        resolve();
+      }, ICE_GATHERING_TIMEOUT_MS);
+      pc.onicegatheringstatechange = () => {
+        if (pc.iceGatheringState === "complete") {
+          clearTimeout(timeout);
+          pc.onicegatheringstatechange = null;
+          resolve();
+        }
+      };
+    });
+
+    const sdpOffer = JSON.stringify(pc.localDescription);
+    const session: CallSession = await this.neighbourhood.callJoin(this.neighbourhoodUrl, this.roomId, sdpOffer);
+    this.state.participantId = session.participantId;
+
+    // Handle SFU redirect (cascaded mode: SFU tells us to connect elsewhere)
+    if (session.redirectTo) {
+      console.info(`SFU redirect: reconnecting to node ${session.redirectTo}`);
+      this.state.connectedNodeDid = session.redirectTo;
+      this.state.sfuPeerDid = session.redirectTo;
+      pc.close();
+      this.state.peerConnection = null;
+      return await this.join(localStream);
+    }
+
+    // The SFU returns a list of participant DIDs already in the room.
+    // Tracks arrive via ontrack; correlation uses CallStreamEvent subscriptions
+    // or the order of received tracks matching the DID list.
+    if (session.streamMapping && session.streamMapping.length > 0) {
+      // Store known participant DIDs for correlation in ontrack handler
+      this.state.knownParticipantDids = session.streamMapping;
+      // Track index counter for DID correlation
+      this.trackDidIndex = 0;
+    }
+
+    const answer = JSON.parse(session.sdpAnswer);
+    await pc.setRemoteDescription(new RTCSessionDescription(answer));
+
+    // Subscribe to server-initiated renegotiation offers (for new peers joining)
+    this.neighbourhood.subscribeCallRenegotiationOffer(this.agentDid, async (event: { reason: string; sdpOffer: string; roomId: string }) => {
+      console.info(`SFU: received renegotiation offer (reason: ${event.reason})`);
+      const currentPc = this.state.peerConnection;
+      if (!currentPc) {
+        console.warn("SFU: no peer connection for renegotiation");
+        return;
+      }
+      try {
+        const offerSdp = JSON.parse(event.sdpOffer);
+        await currentPc.setRemoteDescription(new RTCSessionDescription(offerSdp));
+        const renegAnswer = await currentPc.createAnswer();
+        await currentPc.setLocalDescription(renegAnswer);
+        const answerJson = JSON.stringify(currentPc.localDescription);
+        await this.neighbourhood.callAnswerServerOffer(this.neighbourhoodUrl, event.roomId, answerJson);
+        console.info("SFU: renegotiation answer sent successfully");
+      } catch (err) {
+        console.error("SFU: renegotiation failed:", err);
+        this.emit("error", err);
+      }
+    });
+  }
+
+  async leave(): Promise<void> {
+    if (this.state.peerConnection) {
+      this.state.peerConnection.close();
+      this.state.peerConnection = null;
+    }
+    try { await this.neighbourhood.callLeave(this.neighbourhoodUrl, this.roomId); } catch (e) { console.error("Error leaving SFU call:", e); }
+    for (const [_, participant] of this.state.participants) {
+      this.emit("participant-left", participant);
+    }
+    this.state.participants.clear();
+    this.state.participantId = null;
+  }
+
+  async setQualityPreference(preference: QualityPreference): Promise<void> {
+    if (!this.state.participantId) {
+      console.warn("Cannot set quality preference: not connected to SFU");
+      return;
+    }
+    try {
+      await this.neighbourhood.callSetQualityPreference(this.neighbourhoodUrl, this.roomId, preference);
+    } catch (e) {
+      console.error("Failed to set quality preference:", e);
+      this.emit("error", e);
+    }
+  }
+
+  getState(): Readonly<SfuCallState> { return this.state; }
+  getParticipants(): SfuParticipantState[] { return Array.from(this.state.participants.values()); }
+
+  async destroy(): Promise<void> {
+    // Notify SFU server before closing the connection
+    try { await this.leave(); } catch (e) { console.error("Error during SFU destroy:", e); }
+    this.callbacks.clear();
+    this.streamToParticipant.clear();
+  }
+}

--- a/packages/webrtc/src/index.ts
+++ b/packages/webrtc/src/index.ts
@@ -1,2 +1,3 @@
 export * from './ad4mPeer';
 export * from './WebRTCManager';
+export * from './SfuManager';

--- a/packages/webrtc/vitest.config.ts
+++ b/packages/webrtc/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@coasys/hooks-helpers': 0.13.0-test-8
+  '@coasys/hooks-helpers': 0.13.0-test-9
   '@preact/preset-vite': 2.9.4
+  '@babel/core': ^7.26.0
   '@coasys/flux-api': workspace:*
   '@coasys/flux-comment-section': workspace:*
   '@coasys/flux-constants': workspace:*
@@ -18,10 +19,10 @@ overrides:
   '@coasys/flux-utils': workspace:*
   '@coasys/flux-vue': workspace:*
   '@coasys/flux-webrtc': workspace:*
-  '@coasys/ad4m': 0.13.0-test-8
-  '@coasys/ad4m-connect': 0.13.0-localhost-wildcard-1
-  '@coasys/ad4m-vue-hooks': 0.13.0-test-8
-  '@coasys/ad4m-react-hooks': 0.13.0-test-8
+  '@coasys/ad4m': 0.13.0-test-9
+  '@coasys/ad4m-connect': 0.13.0-test-9
+  '@coasys/ad4m-vue-hooks': 0.13.0-test-9
+  '@coasys/ad4m-react-hooks': 0.13.0-test-9
 
 importers:
 
@@ -53,7 +54,7 @@ importers:
   app:
     dependencies:
       '@babel/core':
-        specifier: '*'
+        specifier: ^7.26.0
         version: 7.29.7
       '@capacitor/android':
         specifier: ^7.6.0
@@ -74,14 +75,14 @@ importers:
         specifier: ^7.0.5
         version: 7.0.6(@capacitor/core@7.6.6)
       '@coasys/ad4m':
-        specifier: 0.13.0-test-8
-        version: 0.13.0-test-8
+        specifier: 0.13.0-test-9
+        version: 0.13.0-test-9
       '@coasys/ad4m-connect':
-        specifier: 0.13.0-localhost-wildcard-1
-        version: 0.13.0-localhost-wildcard-1
+        specifier: 0.13.0-test-9
+        version: 0.13.0-test-9
       '@coasys/ad4m-vue-hooks':
-        specifier: 0.13.0-test-8
-        version: 0.13.0-test-8(vue@3.5.35(typescript@5.9.3))
+        specifier: 0.13.0-test-9
+        version: 0.13.0-test-9(vue@3.5.35(typescript@5.9.3))
       '@coasys/flux-api':
         specifier: workspace:*
         version: link:../packages/api
@@ -329,8 +330,8 @@ importers:
   packages/api:
     dependencies:
       '@coasys/ad4m':
-        specifier: 0.13.0-test-8
-        version: 0.13.0-test-8
+        specifier: 0.13.0-test-9
+        version: 0.13.0-test-9
       '@coasys/flux-constants':
         specifier: workspace:*
         version: link:../constants
@@ -346,13 +347,13 @@ importers:
     devDependencies:
       vitest:
         specifier: ^2
-        version: 2.1.9(@types/node@25.9.1)(sass@1.100.0)(terser@5.48.0)
+        version: 2.1.9(@types/node@25.9.1)(jsdom@24.1.3)(sass@1.100.0)(terser@5.48.0)
 
   packages/comment-section:
     dependencies:
       '@coasys/ad4m':
-        specifier: 0.13.0-test-8
-        version: 0.13.0-test-8
+        specifier: 0.13.0-test-9
+        version: 0.13.0-test-9
       '@coasys/flux-editor':
         specifier: workspace:*
         version: link:../flux-editor
@@ -393,11 +394,11 @@ importers:
   packages/create/templates/preact:
     dependencies:
       '@coasys/ad4m':
-        specifier: 0.13.0-test-8
-        version: 0.13.0-test-8
+        specifier: 0.13.0-test-9
+        version: 0.13.0-test-9
       '@coasys/ad4m-react-hooks':
-        specifier: 0.13.0-test-8
-        version: 0.13.0-test-8(preact@10.29.2)(react@18.3.1)
+        specifier: 0.13.0-test-9
+        version: 0.13.0-test-9(preact@10.29.2)(react@18.3.1)
       '@coasys/flux-api':
         specifier: workspace:*
         version: link:../../../api
@@ -427,11 +428,11 @@ importers:
   packages/create/templates/vue:
     dependencies:
       '@coasys/ad4m':
-        specifier: 0.13.0-test-8
-        version: 0.13.0-test-8
+        specifier: 0.13.0-test-9
+        version: 0.13.0-test-9
       '@coasys/ad4m-vue-hooks':
-        specifier: 0.13.0-test-8
-        version: 0.13.0-test-8(vue@3.5.35(typescript@5.9.3))
+        specifier: 0.13.0-test-9
+        version: 0.13.0-test-9(vue@3.5.35(typescript@5.9.3))
       '@coasys/flux-api':
         specifier: workspace:*
         version: link:../../../api
@@ -461,11 +462,11 @@ importers:
   packages/flux-container:
     dependencies:
       '@coasys/ad4m':
-        specifier: 0.13.0-test-8
-        version: 0.13.0-test-8
+        specifier: 0.13.0-test-9
+        version: 0.13.0-test-9
       '@coasys/ad4m-connect':
-        specifier: 0.13.0-localhost-wildcard-1
-        version: 0.13.0-localhost-wildcard-1
+        specifier: 0.13.0-test-9
+        version: 0.13.0-test-9
       '@coasys/flux-api':
         specifier: workspace:*
         version: link:../api
@@ -489,11 +490,11 @@ importers:
   packages/flux-editor:
     dependencies:
       '@coasys/ad4m':
-        specifier: 0.13.0-test-8
-        version: 0.13.0-test-8
+        specifier: 0.13.0-test-9
+        version: 0.13.0-test-9
       '@coasys/ad4m-connect':
-        specifier: 0.13.0-localhost-wildcard-1
-        version: 0.13.0-localhost-wildcard-1
+        specifier: 0.13.0-test-9
+        version: 0.13.0-test-9
       '@coasys/flux-api':
         specifier: workspace:*
         version: link:../api
@@ -538,8 +539,8 @@ importers:
   packages/react-web:
     dependencies:
       '@coasys/ad4m':
-        specifier: 0.13.0-test-8
-        version: 0.13.0-test-8
+        specifier: 0.13.0-test-9
+        version: 0.13.0-test-9
       '@coasys/flux-api':
         specifier: workspace:*
         version: link:../api
@@ -607,11 +608,11 @@ importers:
   packages/utils:
     dependencies:
       '@coasys/ad4m':
-        specifier: 0.13.0-test-8
-        version: 0.13.0-test-8
+        specifier: 0.13.0-test-9
+        version: 0.13.0-test-9
       '@coasys/ad4m-connect':
-        specifier: 0.13.0-localhost-wildcard-1
-        version: 0.13.0-localhost-wildcard-1
+        specifier: 0.13.0-test-9
+        version: 0.13.0-test-9
       '@coasys/flux-constants':
         specifier: workspace:*
         version: link:../constants
@@ -631,8 +632,8 @@ importers:
   packages/vue:
     dependencies:
       '@coasys/ad4m':
-        specifier: 0.13.0-test-8
-        version: 0.13.0-test-8
+        specifier: 0.13.0-test-9
+        version: 0.13.0-test-9
       '@coasys/flux-api':
         specifier: workspace:*
         version: link:../api
@@ -652,20 +653,27 @@ importers:
   packages/webrtc:
     dependencies:
       '@coasys/ad4m':
-        specifier: 0.13.0-test-8
-        version: 0.13.0-test-8
+        specifier: 0.13.0-test-9
+        version: 0.13.0-test-9
       simple-peer:
         specifier: ^9.11.1
         version: 9.11.1
+    devDependencies:
+      jsdom:
+        specifier: ^24.0.0
+        version: 24.1.3
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@25.9.1)(jsdom@24.1.3)(sass@1.100.0)(terser@5.48.0)
 
   views/chat-view:
     dependencies:
       '@coasys/ad4m':
-        specifier: 0.13.0-test-8
-        version: 0.13.0-test-8
+        specifier: 0.13.0-test-9
+        version: 0.13.0-test-9
       '@coasys/ad4m-react-hooks':
-        specifier: 0.13.0-test-8
-        version: 0.13.0-test-8(preact@10.29.2)(react@18.3.1)
+        specifier: 0.13.0-test-9
+        version: 0.13.0-test-9(preact@10.29.2)(react@18.3.1)
       '@coasys/flux-api':
         specifier: workspace:*
         version: link:../../packages/api
@@ -722,8 +730,8 @@ importers:
         specifier: ^1.70.19
         version: 1.80.0
       '@coasys/ad4m':
-        specifier: 0.13.0-test-8
-        version: 0.13.0-test-8
+        specifier: 0.13.0-test-9
+        version: 0.13.0-test-9
       '@coasys/flux-container':
         specifier: workspace:*
         version: link:../../packages/flux-container
@@ -753,11 +761,11 @@ importers:
   views/kanban-view:
     dependencies:
       '@coasys/ad4m':
-        specifier: 0.13.0-test-8
-        version: 0.13.0-test-8
+        specifier: 0.13.0-test-9
+        version: 0.13.0-test-9
       '@coasys/ad4m-react-hooks':
-        specifier: 0.13.0-test-8
-        version: 0.13.0-test-8(preact@10.29.2)(react@18.3.1)
+        specifier: 0.13.0-test-9
+        version: 0.13.0-test-9(preact@10.29.2)(react@18.3.1)
       '@coasys/flux-api':
         specifier: workspace:*
         version: link:../../packages/api
@@ -781,7 +789,7 @@ importers:
         version: 10.29.2
       react-beautiful-dnd:
         specifier: ^13.1.1
-        version: 13.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 13.1.1(react-dom@19.2.7(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@babel/plugin-proposal-class-properties':
         specifier: ^7.18.6
@@ -802,11 +810,11 @@ importers:
   views/kanban-view-simple:
     dependencies:
       '@coasys/ad4m':
-        specifier: 0.13.0-test-8
-        version: 0.13.0-test-8
+        specifier: 0.13.0-test-9
+        version: 0.13.0-test-9
       '@coasys/ad4m-react-hooks':
-        specifier: 0.13.0-test-8
-        version: 0.13.0-test-8(preact@10.29.2)(react@18.3.1)
+        specifier: 0.13.0-test-9
+        version: 0.13.0-test-9(preact@10.29.2)(react@18.3.1)
       '@coasys/flux-api':
         specifier: workspace:*
         version: link:../../packages/api
@@ -830,7 +838,7 @@ importers:
         version: 10.29.2
       react-beautiful-dnd:
         specifier: ^13.1.1
-        version: 13.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 13.1.1(react-dom@19.2.7(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@babel/plugin-proposal-class-properties':
         specifier: ^7.18.6
@@ -854,11 +862,11 @@ importers:
         specifier: '=3.6.9'
         version: 3.6.9(graphql@16.14.1)(react@18.3.1)
       '@coasys/ad4m':
-        specifier: 0.13.0-test-8
-        version: 0.13.0-test-8
+        specifier: 0.13.0-test-9
+        version: 0.13.0-test-9
       '@coasys/ad4m-react-hooks':
-        specifier: 0.13.0-test-8
-        version: 0.13.0-test-8(preact@10.29.2)(react@18.3.1)
+        specifier: 0.13.0-test-9
+        version: 0.13.0-test-9(preact@10.29.2)(react@18.3.1)
       '@coasys/flux-api':
         specifier: workspace:*
         version: link:../../packages/api
@@ -957,16 +965,14 @@ importers:
         specifier: ^3.1.0
         version: 3.5.2(vite@4.5.14(@types/node@25.9.1)(sass@1.100.0)(terser@5.48.0))
 
-  views/nillion-file-store/dist: {}
-
   views/poll-view:
     dependencies:
       '@coasys/ad4m':
-        specifier: 0.13.0-test-8
-        version: 0.13.0-test-8
+        specifier: 0.13.0-test-9
+        version: 0.13.0-test-9
       '@coasys/ad4m-react-hooks':
-        specifier: 0.13.0-test-8
-        version: 0.13.0-test-8(preact@10.29.2)(react@18.3.1)
+        specifier: 0.13.0-test-9
+        version: 0.13.0-test-9(preact@10.29.2)(react@18.3.1)
       '@coasys/flux-api':
         specifier: workspace:*
         version: link:../../packages/api
@@ -999,11 +1005,11 @@ importers:
   views/post-view:
     dependencies:
       '@coasys/ad4m':
-        specifier: 0.13.0-test-8
-        version: 0.13.0-test-8
+        specifier: 0.13.0-test-9
+        version: 0.13.0-test-9
       '@coasys/ad4m-react-hooks':
-        specifier: 0.13.0-test-8
-        version: 0.13.0-test-8(preact@10.29.2)(react@18.3.1)
+        specifier: 0.13.0-test-9
+        version: 0.13.0-test-9(preact@10.29.2)(react@18.3.1)
       '@coasys/flux-api':
         specifier: workspace:*
         version: link:../../packages/api
@@ -1078,11 +1084,11 @@ importers:
   views/synergy-demo-view:
     dependencies:
       '@coasys/ad4m':
-        specifier: 0.13.0-test-8
-        version: 0.13.0-test-8
+        specifier: 0.13.0-test-9
+        version: 0.13.0-test-9
       '@coasys/ad4m-react-hooks':
-        specifier: 0.13.0-test-8
-        version: 0.13.0-test-8(preact@10.29.2)(react@18.3.1)
+        specifier: 0.13.0-test-9
+        version: 0.13.0-test-9(preact@10.29.2)(react@18.3.1)
       '@coasys/flux-api':
         specifier: workspace:*
         version: link:../../packages/api
@@ -1118,11 +1124,11 @@ importers:
   views/table-view:
     dependencies:
       '@coasys/ad4m':
-        specifier: 0.13.0-test-8
-        version: 0.13.0-test-8
+        specifier: 0.13.0-test-9
+        version: 0.13.0-test-9
       '@coasys/ad4m-react-hooks':
-        specifier: 0.13.0-test-8
-        version: 0.13.0-test-8(preact@10.29.2)(react@18.3.1)
+        specifier: 0.13.0-test-9
+        version: 0.13.0-test-9(preact@10.29.2)(react@18.3.1)
       '@coasys/flux-api':
         specifier: workspace:*
         version: link:../../packages/api
@@ -1161,8 +1167,8 @@ importers:
   views/webrtc-debug:
     dependencies:
       '@coasys/ad4m-react-hooks':
-        specifier: 0.13.0-test-8
-        version: 0.13.0-test-8(preact@10.29.2)(react@18.3.1)
+        specifier: 0.13.0-test-9
+        version: 0.13.0-test-9(preact@10.29.2)(react@18.3.1)
       '@coasys/flux-container':
         specifier: workspace:*
         version: link:../../packages/flux-container
@@ -1210,11 +1216,11 @@ importers:
   views/webrtc-view:
     dependencies:
       '@coasys/ad4m':
-        specifier: 0.13.0-test-8
-        version: 0.13.0-test-8
+        specifier: 0.13.0-test-9
+        version: 0.13.0-test-9
       '@coasys/ad4m-react-hooks':
-        specifier: 0.13.0-test-8
-        version: 0.13.0-test-8(preact@10.29.2)(react@18.3.1)
+        specifier: 0.13.0-test-9
+        version: 0.13.0-test-9(preact@10.29.2)(react@18.3.1)
       '@coasys/flux-container':
         specifier: workspace:*
         version: link:../../packages/flux-container
@@ -1365,6 +1371,9 @@ packages:
       subscriptions-transport-ws:
         optional: true
 
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
   '@babel/code-frame@7.12.11':
     resolution: {integrity: sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==}
 
@@ -1396,18 +1405,18 @@ packages:
     resolution: {integrity: sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': ^7.26.0
 
   '@babel/helper-create-regexp-features-plugin@7.29.7':
     resolution: {integrity: sha512-907Uymvqgg1dwUA+7IGwFAOSYzQOuzPXKNJ1yxzwPffzkYFg2q2eHi1fIOs6sXkG9NbIUMunnUlkYsfRFNvomg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': ^7.26.0
 
   '@babel/helper-define-polyfill-provider@0.6.8':
     resolution: {integrity: sha512-47UwBLPpQi1NoWzLuHNjRoHlYXMwIJoBf7MFou6viC/sIHWYygpvr0B6IAyh5sBdA2nr2LPIRww8lfaUVQINBA==}
     peerDependencies:
-      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+      '@babel/core': ^7.26.0
 
   '@babel/helper-globals@7.29.7':
     resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
@@ -1425,7 +1434,7 @@ packages:
     resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': ^7.26.0
 
   '@babel/helper-optimise-call-expression@7.29.7':
     resolution: {integrity: sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==}
@@ -1439,13 +1448,13 @@ packages:
     resolution: {integrity: sha512-16AMiW26DbXWBbr3B8wNozKM0ydMLB892vaOaJW/fPJdnT8vJk5sdkQcU/isqUxyCE0cEoa8wZOcbgDuC4b6Og==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': ^7.26.0
 
   '@babel/helper-replace-supers@7.29.7':
     resolution: {integrity: sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': ^7.26.0
 
   '@babel/helper-skip-transparent-expression-wrappers@7.29.7':
     resolution: {integrity: sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==}
@@ -1484,494 +1493,494 @@ packages:
     resolution: {integrity: sha512-j8SrR0zLZrRsC09DlszEx8FpMiwukKffYXMK0d5LmOglO7vGG6sz/BR/20yHqWH+Lnn31JTt2PE3hIWNgM2J6w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.29.7':
     resolution: {integrity: sha512-r8j8escF+U2FUHo0KOhPUdMzUO+jp9fInva6+ACVAF3Y97Ev+5iNZwiqTghmzNeWwDkOPlYuTcfb1vDaoZKmAQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.29.7':
     resolution: {integrity: sha512-GE1TFSiuFeGsCxmYXZl8HwoPrVlwe4rHPFE8weieGKZqnDORK+Ar3vgWMgW+AOxQ6/2TgLSKx9p6W7O4rC6qgQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@7.29.7':
     resolution: {integrity: sha512-oBNVCvnO5tND+xSopWvV8WNGfpTfgP4Zr/YXXSj8zfmcPktp5Ku/aZlsIowgSD4fjmgHn6sGmB9APVsU5zOdhA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.29.7':
     resolution: {integrity: sha512-QQt9qKHZ2sg/kivaLr7lnQr8HVrQDdBNSfCsTjiDxRuX/K5ORyKq+Bu8Xr0cDE3Dfkv0cw28Ve0EKyKMvulkOw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.13.0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.29.7':
     resolution: {integrity: sha512-pn6QacGLgvCcwc+syUhKE/qSjV2D1IHDB84RNxWYSt1mW3K/SCtjinZ2p0cETJxAWBjPy3K/1lHwG5BjjPxNlw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-proposal-class-properties@7.18.6':
     resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
     engines: {node: '>=6.9.0'}
     deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-proposal-decorators@7.29.7':
     resolution: {integrity: sha512-EtU0Hi3GvrTqD56xKmZvV/uCXK2ZbwVNPNLAquVItcAZpUhkXwWlo3Fmj0c2LxgSf2I8IDULeAepwNP1OefLXg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2':
     resolution: {integrity: sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-syntax-async-generators@7.8.4':
     resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-syntax-bigint@7.8.3':
     resolution: {integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-syntax-class-properties@7.12.13':
     resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-syntax-class-static-block@7.14.5':
     resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-syntax-decorators@7.29.7':
     resolution: {integrity: sha512-9MTTLbF39X6sqM92JPEsoI7++26hjZvzkxKZy64aMhWLH2mPkJ/Q3AV4QLmls3R14FpSpkOwQQfUh962JGQxxg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-syntax-import-assertions@7.29.7':
     resolution: {integrity: sha512-/An1OCBN93thpBAGyfsK2pcf0jvju1SAtKkL2Ny++B5Sy6sqgzXDQH1cZxWbF96Wuk+bn41MDA9bLd4VVAw6rw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-syntax-import-attributes@7.29.7':
     resolution: {integrity: sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-syntax-import-meta@7.10.4':
     resolution: {integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-syntax-json-strings@7.8.3':
     resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-syntax-jsx@7.29.7':
     resolution: {integrity: sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4':
     resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3':
     resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-syntax-numeric-separator@7.10.4':
     resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-syntax-object-rest-spread@7.8.3':
     resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-syntax-optional-catch-binding@7.8.3':
     resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-syntax-optional-chaining@7.8.3':
     resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-syntax-private-property-in-object@7.14.5':
     resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-syntax-top-level-await@7.14.5':
     resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-syntax-typescript@7.29.7':
     resolution: {integrity: sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-syntax-unicode-sets-regex@7.18.6':
     resolution: {integrity: sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-arrow-functions@7.29.7':
     resolution: {integrity: sha512-N7zArUXWzAMzm+/N0uPBeVB3Fam5lMxtUwMmDK5f/IBBS7a7p1qeUoxd/6CckXoxUdgsntq1Dh8xNW06maZbDQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-async-generator-functions@7.29.7':
     resolution: {integrity: sha512-d98gXZkgswvkyohMBABkhm3GeXhYj8psWfwQ2C7gtfrKGTykQa/iOIi+JJhwMjPlZ6Vm2XN+DCf3Es1EoG4ZLA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-async-to-generator@7.29.7':
     resolution: {integrity: sha512-pcUb2SS+RMo9TWVBwKGI5ShtoG7R+zBsFmCKDa6fe8c+hPr3XJlZgoE5j6i8W7gDjhyvy+85vmYexanvXh3d1w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-block-scoped-functions@7.29.7':
     resolution: {integrity: sha512-cUSmjh72N+rN4PrkFlN1dJwNCwjVp5d38/CQrEsFggkD10UiFlBFgdH3tv5dNsLuHY+3S8db2xCHjhZcv5WgvA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-block-scoping@7.29.7':
     resolution: {integrity: sha512-ONyr4+AZhKh8yKWInVxU9AXA9EbsyeLcL6V0dJy6M2/62vuvpGm29zzuymbTpdc451GEpDIdAyPLP3r+P61yKQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-class-properties@7.29.7':
     resolution: {integrity: sha512-GtcpjFvanPfzNQi3eTitsCqtRRmmqzpy/A+yhTR1HaZo1Ly3EA8ZXxlPyHdR8/IuRMYc3E4wdGBewB2QKQjAaA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-class-static-block@7.29.7':
     resolution: {integrity: sha512-kibJgmEdX2iMwsHY2tSZNDgj8PwIlCQz7FK9KuGKO8zsuoUwSEhoNnNVp/emKWrbY4HeO6kkXfdMqRKKKXBm2A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.12.0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-classes@7.29.7':
     resolution: {integrity: sha512-qV0OGGBVacduzQHE649JyCneOFI/maT+YKsO+K4Yi3xv2wTPNjM/W2o2gdzMwEAZz7fXNTHAe0NcSg30bIN69g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-computed-properties@7.29.7':
     resolution: {integrity: sha512-RK7/IyU5phpuCdBAuig5VkzG/EnbDaui5SQGdU9BFrHdV+mV4cUjLMQ9lJDjLNtWHsqtiefpGZUXQP2BiTYMsA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-destructuring@7.29.7':
     resolution: {integrity: sha512-iPX8aD6H9zV5s7ZsqTdNocPN/MGQ5sSMnElKrktxjJRMnB2jN/1p2+R7GkfD6CAYoVFqy5A4XnSIUeGgJzIWpg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-dotall-regex@7.29.7':
     resolution: {integrity: sha512-3qc18hsD2RdZiyJNDNc7HQpv6xbncwh8FYtxNFFzclSyh/trPD9KkVR9BDECUjDLvb7yJVF15GfYUuC+LMkkiQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-duplicate-keys@7.29.7':
     resolution: {integrity: sha512-6IvRRriEMqnBwD6chtxdLpMYCHWEzN+oL5cyQtjykya19UgzbmKhxmhZgKC/LHxS2nYr9Q/qYPZ5Lr6jOL9+yQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.7':
     resolution: {integrity: sha512-2wiIyo2BjtgU7HufSeDnL9L2O7zr8jmhFKuSr65VpRkUiRKRNpb0mdlk56+XPPKoIrfHqzbMuglDvZun0RISsA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-dynamic-import@7.29.7':
     resolution: {integrity: sha512-giOlEm/EFjfjr+te9NsdjkUo2v4f8rS/SXPumRVHAtbNcyNlvtREkU1dZzaIDclNpnaVhlCqRdFKhJBjBikzLg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-explicit-resource-management@7.29.7':
     resolution: {integrity: sha512-Rstj7coNz8sE+7Ju7ihpHLI564lsK5pUpNNlvptCIC/16E/S5hbl6n3kESPKdNRmqEWlpn5xpS5Q2dvXBsySLw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-exponentiation-operator@7.29.7':
     resolution: {integrity: sha512-zFpMOTLZBdW5LfObqcSbL6kefg4R4eLdmvS0wbN9M6D5Mym/sKm9toOoWyVOa+xDjvCnuWcHls2YonXwHvH3CQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-export-namespace-from@7.29.7':
     resolution: {integrity: sha512-24B2nOy2TeJSMheqwPD4DDQOV/elLSIlKxjZt4i05H5AgdPdWR3n18HnNrcJ+j76WJd9gbwb9jPjNYUy6RautA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-for-of@7.29.7':
     resolution: {integrity: sha512-zeSIHh0+E1Um1WJRXCFlHQYu2ieJNdivLLjlBEp+dIBu3S51n+SZZmIXjxnItw6pz56Cn+KvK68BIBVsxq2JiQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-function-name@7.29.7':
     resolution: {integrity: sha512-otRWaHXE6fbAGkePvaj/kvs3HsqXfPhlnzwSOlnFgbqCPMd975dW+4wZ00WFBt+/YlBGcJwNrARQTOJOb4ZrIg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-json-strings@7.29.7':
     resolution: {integrity: sha512-RRnE2+eon1rJAq8MnoF1b5kTpY1vU88twHcvcKMrsqP/jxIRqDVs9iJB5fqPuqyeFAW0wJo4MlUIPpQCq/aRsg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-literals@7.29.7':
     resolution: {integrity: sha512-DZ/oLP21ZuWx1vKqnoNv6/tvEK48AQOBRai40CX9dTjGluvT/YZCyY3rryDtyUqCEoyNroy5KKPwX2iQCiRvyw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-logical-assignment-operators@7.29.7':
     resolution: {integrity: sha512-A0H91hh6W8MFRkp5TqJmMr39jzGD1A1E1Ysiv2O06Sfbhkapm+XyIzxWCEh5kqwOZ1/8QZ0dY3SeQ7XBqfJd5Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-member-expression-literals@7.29.7':
     resolution: {integrity: sha512-hl1kwFZCCiDyfH25Xmco9jTrkPgnS9pmOzSG7W5I4SaGbLeqKv417hcU2RKmaxoPEgsoJh7ZPOrnPGq99bHoUg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-modules-amd@7.29.7':
     resolution: {integrity: sha512-fxtQoH3m5ywUSIfaH0FGCzWu4McsYon5bD3K4XnskC7f+OyQMj7rsOMi4NvvmJ83WwBAg4UCe+ov4VZlqEvyew==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-modules-commonjs@7.29.7':
     resolution: {integrity: sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-modules-systemjs@7.29.7':
     resolution: {integrity: sha512-TM2ZcQLoG2/y4HODiStCo10DibYhWhGWAwVv+EQKmG/7GFl0N+AAmUiXOMKM+aiJ9XBJ9AHVZBvTzMnJ2sM3cQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-modules-umd@7.29.7':
     resolution: {integrity: sha512-B4UkaTK3QpgCwJnrxKfMPKdo92CN7OKXAlpAAnM3UPu0Q0lCCk57ylA9AJbRy2v8dDKOPAAWcoR6CMyeoHwRCA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-named-capturing-groups-regex@7.29.7':
     resolution: {integrity: sha512-vuFoLwr4qnv2xbZ16SQd6uPcH5FNrLHhk/Jzo++0XJFcaDsr4gjJVg6j398oMHiC+83k/GiBzviwF5KBJkPUtQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-new-target@7.29.7':
     resolution: {integrity: sha512-fEo41GmsOUhOBlw8ioo6zvjX5Xc2Lqkzlyfqbpsk3eB6TReV18uhxZ0esfEokVbY2+PVJAQHNKxER6lGrzNd3A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-nullish-coalescing-operator@7.29.7':
     resolution: {integrity: sha512-idmp1dFaekP9GbcMvG24Kvw2BfhFZjHnNJCkV4WuIY4PskJzwI3f1N5OdgYke38T7rftO6ERulFRn2cFeZwRkg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-numeric-separator@7.29.7':
     resolution: {integrity: sha512-zR7fv/z14OjgHl4AgRtkDBvBMhIzCxqV/qN/2BCRC7LjFwvuzjYe7gDWxC4Wl/SNsLM6SE1IWvRPYMgSJaUvNw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-object-rest-spread@7.29.7':
     resolution: {integrity: sha512-Ld98jn4c0smUywL57m7SgsHq3OpThOa6LqZJif3G6jYOovPleoFhVrBJ1WegRApSFB2wu4+RelAj9AC9G08Z4A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-object-super@7.29.7':
     resolution: {integrity: sha512-Ea/diGcw0twB5IlZPO5sgET6fJsLJqPABqTuFWIR+iMPGPZJkATEIWx0wa+aEQ5UY1CBQyP/gkAiLEqn1vBiQA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-optional-catch-binding@7.29.7':
     resolution: {integrity: sha512-sLsyndxK2VwX6yNUOakMb7Sh553ZTe/vVM1XJ+9Z5aW1ytsc8xOIwmyk05NNjN60vkc5/KqoTH6hB4V41LJhng==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-optional-chaining@7.29.7':
     resolution: {integrity: sha512-6GM1dhvK3gNODkXcEcMCOLEDCLSoZ/sBbro2Ax8HURyasQ4NshagQixkRFdh5niI6E4gmA/jYI/4aT7rRos3ZQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-parameters@7.29.7':
     resolution: {integrity: sha512-ZDOBqV/qLYJI0YElr8DcENEyARsFQeESqWXH6gZlghYXuPPjvweuDhP4VyEi4BlUBlLRFZVjxoZDMjxhLW766g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-private-methods@7.29.7':
     resolution: {integrity: sha512-/6Rz4DK1ETDEM/bWHsPHcaEe7ZaT1EqSXjtSP/L0DijOYuaUhiRiOKcwpZ8P7zR4xXEHc2ITdiCgBm9Tpyv9ug==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-private-property-in-object@7.29.7':
     resolution: {integrity: sha512-+BNo06dnrzdNNqCm1X6YUaVv0DKk8Q+JYcoZfOkLhYWNCXzlwTSRq8zGWayT1csjcpNXV9CQTBRRbmTLZac5cA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-property-literals@7.29.7':
     resolution: {integrity: sha512-bOMRLQuI0A5ZqHq3OWJ89/rXpJ/NJrbVhXiP4zwPGMs6kpcVsuTUNjwoE30K0Qm3mf48a/TnRYYD6vPNqcg6jA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-react-jsx-development@7.29.7':
     resolution: {integrity: sha512-Xfy3UVMF04+ypnFbkhvfqtmvwfe92qwQdbGZVonhE+6v35GzlofmOnA1szaZqzb9xYWr0nl1e5EMmzi0DNON1g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-react-jsx@7.29.7':
     resolution: {integrity: sha512-WsZulLVBUHXVj2cUcPVx6UE21TpalB6bHbSFErKT0Ib++ax24jjXe73FqlWvdylFOjiuPHYi6VCcgRad1ItN+A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-regenerator@7.29.7':
     resolution: {integrity: sha512-rNNFV0DBAJp988xW2DOntfDoYn1eR8GGF5AT5vYc+rjyfaQkM242c9tZUHHPe7KYaiJizXPWhQTzzdbXySyhBw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-regexp-modifiers@7.29.7':
     resolution: {integrity: sha512-mB5Fs0VWrJ42ZCmc8114v60qetdaUVNkj9PmSZRmanCZM3S9hm0CFRLjRmYIsuXav14l2jvZ+4T8iiCGnhj3nQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-reserved-words@7.29.7':
     resolution: {integrity: sha512-5+YhdpVgmfSmwZyLMftfaiffLRMHjzIRHFHHLdibcSyJm2pasMrKHrO3Ptrt2DRshjvpgjEJJ1zVW14WPq/6QA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-shorthand-properties@7.29.7':
     resolution: {integrity: sha512-I+WYbGBAiCn7nA6xBrlgPH+MB7HWb4u8pv5S0Pv7OtwNvIFvCCb24YlttKEeUFVurfBCEaOTnuhlqsb7f0Z5Dg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-spread@7.29.7':
     resolution: {integrity: sha512-/u5K1QWada7tbYNqTjMh96718g9NTwh9tfPJMsSmVsQwGT447FskV+KcfeXkXq2GWki4EM/MuTdmBec+hOuVTQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-sticky-regex@7.29.7':
     resolution: {integrity: sha512-BCHzNYJGe9l7EpwwDBN/ztlL2NYFFq8hp9ddjtUEM9f2O7S7kKV/lL6Fwo7IF7NSkYhPK2vO+86nIGltA90MsA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-template-literals@7.29.7':
     resolution: {integrity: sha512-NCSEJ4sLFU2gqAub45HYh4fus2yQ36rr6ei6vpU7NdoJqCpxvEG8E6eJpscGyXP3VHD2Ny+fSXr04k1hoUrFqA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-typeof-symbol@7.29.7':
     resolution: {integrity: sha512-223mNGoTkBiTEWFoK+Q6Go3tueMRclO8vxxxxquNCYuNI4jWOofFKJRRDu6SDrB8Sgo1UEGW9T4GAQ8ZyRso1A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-unicode-escapes@7.29.7':
     resolution: {integrity: sha512-jCfXxSjf94lf4E0hKE0AByxF6F3/pVFqRdUUNkDJhsY0m1ZKjnN6ZYyMeHNpzflxb/0q5b7t3p+BE+SLF1WOtA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-unicode-property-regex@7.29.7':
     resolution: {integrity: sha512-OgZ+zoAJgZLUCunsTRQ5LAjOywDv5zzZ2/hQ5aMw1pGXyY2rtE8/chXYUmu3AlVHKpm10KEdG9aMwbI/K76ZGw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-unicode-regex@7.29.7':
     resolution: {integrity: sha512-7D/x/23/d/3VqZ0QA+LGbZMlGwZjztBygSWWWsfTPoQ1oQ6Q1P6Mr3d0kk42XabyUVw+fha3LqdRsFqeKqvCyA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/plugin-transform-unicode-sets-regex@7.29.7':
     resolution: {integrity: sha512-BLOhLht9DOJwIxlmp91wHvkXv1lguuHS3/FwUO8HL1H0u8s4hR1gASVFyilu9iGtcTRYqjTZmlsFFeQletntEg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': ^7.26.0
 
   '@babel/preset-env@7.29.7':
     resolution: {integrity: sha512-GYzX36n1nsciIb0uyH0GHwxwtNwPQIcpxSeiVLDtG/B7jB5xXgchnmL1f/jCX5o+pwnaDBtO60ONSJhEBJfxYA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.26.0
 
   '@babel/preset-modules@0.1.6-no-external-plugins':
     resolution: {integrity: sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==}
     peerDependencies:
-      '@babel/core': ^7.0.0-0 || ^8.0.0-0 <8.0.0
+      '@babel/core': ^7.26.0
 
   '@babel/runtime@7.29.7':
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
@@ -2035,25 +2044,25 @@ packages:
     peerDependencies:
       '@capacitor/core': '>=7.0.0'
 
-  '@coasys/ad4m-connect@0.13.0-localhost-wildcard-1':
-    resolution: {integrity: sha512-CDda5l8/1Wi0Vh2jmyQ3wvjH+mCREZBP9nUQQC8rc7Im+K505boz3xhmItvu0ZATOMexyd+/bEShgZUawOgl4Q==}
+  '@coasys/ad4m-connect@0.13.0-test-9':
+    resolution: {integrity: sha512-LM/LsATZeZkyNkbrGJeIVdXppFl27YMxffGnuT9vaqZxGbxoKNcuk30dCG/Gu9Ul851TSnt9CKoFThiJqtA6Jg==}
 
-  '@coasys/ad4m-react-hooks@0.13.0-test-8':
-    resolution: {integrity: sha512-FJ5xXByc2OTpjU2HZXdd23r+NoGyPSYRlwYTX8wgKMcN7I8PL3HNLk5dzidaz4v9bYn7Gh1CnyBvqUi8QUpCnw==}
+  '@coasys/ad4m-react-hooks@0.13.0-test-9':
+    resolution: {integrity: sha512-riuPmyaqlCBo0VZ4AYKiWWJBS7SFDoMj0xjsK3S6Fa444KqZ9inVB7E5TScVexlapo/jDN2AepruTi1k+A6yHA==}
     peerDependencies:
       preact: '*'
       react: '*'
 
-  '@coasys/ad4m-vue-hooks@0.13.0-test-8':
-    resolution: {integrity: sha512-e3+9uOZ6jTNb9pj+0qK9r1BAteAb+bvwGFGq5WhtOdhx2pjoA6iiy6zvjsnKEsFPIAjTt35ODPeQJSy/2HNCkg==}
+  '@coasys/ad4m-vue-hooks@0.13.0-test-9':
+    resolution: {integrity: sha512-2byWxkf+fbpRcGE8UGznNfY9H9o8Euas9w4enm6nzaTXOc5ZfGe0jK6ZPZlBxKX64xp5dJDBcFxCJHchVbjblw==}
     peerDependencies:
       vue: ^3.2.47
 
-  '@coasys/ad4m@0.13.0-test-8':
-    resolution: {integrity: sha512-ux0nJcFCd+otqjMJMAGlXPbtCCqcafYWL3fC+W83ry9sIT6iCTZNDtjdzb3F/tDoSl4qJi9f8GjuHsUEGkp4xA==}
+  '@coasys/ad4m@0.13.0-test-9':
+    resolution: {integrity: sha512-AaHbiV8sAd9/akptihL4vBP97deL97n9fuMBmboSnR+seX+Ad/TTTnQsJ5RruOikgbI/YtE1igqVVVX9zfPqhw==}
 
-  '@coasys/hooks-helpers@0.13.0-test-8':
-    resolution: {integrity: sha512-cynJIZq3GDO/gs6RGHABYNioDKPb8I6ChsA0WRA72jpDZgpWMSzz3BdmuLgJPlsDlhFPNzgGkmY6pNXEJLssxA==}
+  '@coasys/hooks-helpers@0.13.0-test-9':
+    resolution: {integrity: sha512-vwEbqDtVBv5jhkfMKN4V4qxKme1SpgClkaqSeogj4f2qNxfqR13lpUk/emqpYKYzn/6t7z/sPd77O+xzHD3XZA==}
 
   '@confio/ics23@0.6.8':
     resolution: {integrity: sha512-wB6uo+3A50m0sW/EWcU64xpV/8wShZ6bMTa7pF8eYsTrSkQA7oLUIJcs/wb8g4y2Oyq701BaGiO6n/ak5WXO1w==}
@@ -2096,6 +2105,34 @@ packages:
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@docsearch/css@3.9.0':
     resolution: {integrity: sha512-cQbnVbq0rrBwNAKegIac/t6a8nWoUAn8frnkLFW6YARaRmAQr5/Eoe6Ln2fqkUCZ40KpdrKbpSAmgrkviOxuWA==}
@@ -3049,7 +3086,7 @@ packages:
   '@preact/preset-vite@2.9.4':
     resolution: {integrity: sha512-PpPnUlKUsbWZ2oBuAkAMnezhIYGsR7xi2EZcPjeTAjF1DhGl00IcPD1ZeXRFKp38i7Hk4kEdFlwpJ1525cAzpg==}
     peerDependencies:
-      '@babel/core': 7.x
+      '@babel/core': ^7.26.0
       vite: 2.x || 3.x || 4.x || 5.x || 6.x
 
   '@prefresh/babel-plugin@0.5.3':
@@ -3109,7 +3146,7 @@ packages:
     resolution: {integrity: sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': ^7.26.0
       '@types/babel__core': ^7.1.9
       rollup: ^1.20.0||^2.0.0
     peerDependenciesMeta:
@@ -3942,6 +3979,9 @@ packages:
       vite: ^5.0.0 || ^6.0.0
       vue: ^3.2.25
 
+  '@vitest/expect@1.6.1':
+    resolution: {integrity: sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==}
+
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
 
@@ -3959,14 +3999,26 @@ packages:
   '@vitest/pretty-format@2.1.9':
     resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
 
+  '@vitest/runner@1.6.1':
+    resolution: {integrity: sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==}
+
   '@vitest/runner@2.1.9':
     resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@1.6.1':
+    resolution: {integrity: sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==}
 
   '@vitest/snapshot@2.1.9':
     resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
 
+  '@vitest/spy@1.6.1':
+    resolution: {integrity: sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==}
+
   '@vitest/spy@2.1.9':
     resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@1.6.1':
+    resolution: {integrity: sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==}
 
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
@@ -4201,6 +4253,10 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   agentkeepalive@4.6.0:
     resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
     engines: {node: '>= 8.0.0'}
@@ -4400,6 +4456,9 @@ packages:
   asn1.js@4.10.1:
     resolution: {integrity: sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==}
 
+  assertion-error@1.1.0:
+    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -4471,7 +4530,7 @@ packages:
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
-      '@babel/core': ^7.8.0
+      '@babel/core': ^7.26.0
 
   babel-plugin-istanbul@6.1.1:
     resolution: {integrity: sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==}
@@ -4484,33 +4543,33 @@ packages:
   babel-plugin-polyfill-corejs2@0.4.17:
     resolution: {integrity: sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w==}
     peerDependencies:
-      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+      '@babel/core': ^7.26.0
 
   babel-plugin-polyfill-corejs3@0.14.2:
     resolution: {integrity: sha512-coWpDLJ410R781Npmn/SIBZEsAetR4xVi0SxLMXPaMO4lSf1MwnkGYMtkFxew0Dn8B3/CpbpYxN0JCgg8mn67g==}
     peerDependencies:
-      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+      '@babel/core': ^7.26.0
 
   babel-plugin-polyfill-regenerator@0.6.8:
     resolution: {integrity: sha512-M762rNHfSF1EV3SLtnCJXFoQbbIIz0OyRwnCmV0KPC7qosSfCO0QLTSuJX3ayAebubhE6oYBAYPrBA5ljowaZg==}
     peerDependencies:
-      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+      '@babel/core': ^7.26.0
 
   babel-plugin-transform-hook-names@1.0.2:
     resolution: {integrity: sha512-5gafyjyyBTTdX/tQQ0hRgu4AhNHG/hqWi0ZZmg2xvs2FgRkJXzDNKBZCyoYqgFkovfDrgM8OoKg8karoUvWeCw==}
     peerDependencies:
-      '@babel/core': ^7.12.10
+      '@babel/core': ^7.26.0
 
   babel-preset-current-node-syntax@1.2.0:
     resolution: {integrity: sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==}
     peerDependencies:
-      '@babel/core': ^7.0.0 || ^8.0.0-0
+      '@babel/core': ^7.26.0
 
   babel-preset-jest@29.6.3:
     resolution: {integrity: sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': ^7.26.0
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -4814,6 +4873,10 @@ packages:
     resolution: {integrity: sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w==}
     engines: {node: '>=6'}
 
+  chai@4.5.0:
+    resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
+    engines: {node: '>=4'}
+
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
@@ -4836,6 +4899,9 @@ packages:
 
   chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
+
+  check-error@1.0.3:
+    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
 
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
@@ -5032,6 +5098,9 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
   config-chain@1.1.13:
     resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
 
@@ -5205,6 +5274,10 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -5356,6 +5429,10 @@ packages:
     resolution: {integrity: sha512-QmU3lyEnbENQPo0M1F9BMu4s6cqNNp8iJA+b/HP2sSb7pf3dxwF3+EP1eO69rwBfH9kFJ1apmzrtogAmVt2/Xw==}
     engines: {node: '>=12'}
 
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
+
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
     engines: {node: '>= 0.4'}
@@ -5423,6 +5500,9 @@ packages:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
   decompress-response@3.3.0:
     resolution: {integrity: sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==}
     engines: {node: '>=4'}
@@ -5442,6 +5522,10 @@ packages:
     peerDependenciesMeta:
       babel-plugin-macros:
         optional: true
+
+  deep-eql@4.1.4:
+    resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
+    engines: {node: '>=6'}
 
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
@@ -5730,6 +5814,10 @@ packages:
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
   entities@7.0.1:
@@ -6184,6 +6272,10 @@ packages:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
 
+  execa@8.0.1:
+    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
+    engines: {node: '>=16.17'}
+
   exit@0.1.2:
     resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
     engines: {node: '>= 0.8.0'}
@@ -6465,6 +6557,9 @@ packages:
     resolution: {integrity: sha512-+CEb+GDCM7tkOS2wdMKTn9vU7DgnKUTuDlehkNJKNSovdCOVxs14OfKCk4cvSaR3za4gj+OBdl9opPN9xrJ0zA==}
     hasBin: true
 
+  get-func-name@2.0.2:
+    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
+
   get-installed-path@2.1.1:
     resolution: {integrity: sha512-Qkn9eq6tW5/q9BDVdMpB8tOHljX9OSP0jRC5TRNVA4qRc839t4g8KQaR8t0Uv0EFVL0MlyG7m/ofjEgAROtYsA==}
 
@@ -6507,6 +6602,10 @@ packages:
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
+
+  get-stream@8.0.1:
+    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
+    engines: {node: '>=16'}
 
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
@@ -6735,6 +6834,10 @@ packages:
   howler@2.2.4:
     resolution: {integrity: sha512-iARIBPgcQrwtEr+tALF+rapJ8qSc+Set2GJQl7xT1MQzWaVkFebdJhR3alVlSiUf5U7nAANKuj3aWpwerocD5w==}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -6750,6 +6853,10 @@ packages:
     resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
     engines: {node: '>= 6'}
 
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
   http2-wrapper@1.0.3:
     resolution: {integrity: sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==}
     engines: {node: '>=10.19.0'}
@@ -6758,9 +6865,17 @@ packages:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
 
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
+
+  human-signals@5.0.0:
+    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
+    engines: {node: '>=16.17.0'}
 
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
@@ -7042,6 +7157,9 @@ packages:
   is-plain-obj@1.1.0:
     resolution: {integrity: sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==}
     engines: {node: '>=0.10.0'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
   is-promise@2.2.2:
     resolution: {integrity: sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==}
@@ -7364,6 +7482,9 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
   js-yaml@3.14.2:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
     hasBin: true
@@ -7371,6 +7492,15 @@ packages:
   jschardet@3.1.4:
     resolution: {integrity: sha512-/kmVISmrwVwtyYU40iQUOp3SUPk2dhNCMsZBQX0R1/jZ8maaXJ/oZIzUOiyOqcgtLnETFKYChbJ5iDC/eWmFHg==}
     engines: {node: '>=0.1.90'}
+
+  jsdom@24.1.3:
+    resolution: {integrity: sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^2.11.2
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -7629,6 +7759,10 @@ packages:
     resolution: {integrity: sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==}
     engines: {node: '>=8.9.0'}
 
+  local-pkg@0.5.1:
+    resolution: {integrity: sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==}
+    engines: {node: '>=14'}
+
   locate-path@2.0.0:
     resolution: {integrity: sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==}
     engines: {node: '>=4'}
@@ -7704,6 +7838,9 @@ packages:
 
   lossless-json@4.3.0:
     resolution: {integrity: sha512-ToxOC+SsduRmdSuoLZLYAr5zy1Qu7l5XhmPWM3zefCZ5IcrzW/h108qbJUKfOlDlhvhjUK84+8PSVX0kxnit0g==}
+
+  loupe@2.3.7:
+    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
@@ -7866,6 +8003,10 @@ packages:
     resolution: {integrity: sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==}
     engines: {node: '>=8'}
 
+  mimic-fn@4.0.0:
+    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
+    engines: {node: '>=12'}
+
   mimic-response@1.0.1:
     resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
     engines: {node: '>=4'}
@@ -7981,6 +8122,9 @@ packages:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
     engines: {node: '>=10'}
     hasBin: true
+
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
   modify-values@1.0.1:
     resolution: {integrity: sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==}
@@ -8169,12 +8313,19 @@ packages:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
 
+  npm-run-path@5.3.0:
+    resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
   number-is-nan@1.0.1:
     resolution: {integrity: sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==}
     engines: {node: '>=0.10.0'}
+
+  nwsapi@2.2.24:
+    resolution: {integrity: sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -8226,6 +8377,10 @@ packages:
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
+
+  onetime@6.0.0:
+    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
+    engines: {node: '>=12'}
 
   onnx-proto@4.0.4:
     resolution: {integrity: sha512-aldMOB3HRoo6q/phyB6QRQxSt895HNNw82BNyZ2CMh4bjeKv7g/c+VpAFtJuEMVfYLMbRx61hbuqnKceLeDcDA==}
@@ -8326,6 +8481,10 @@ packages:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
 
+  p-limit@5.0.0:
+    resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
+    engines: {node: '>=18'}
+
   p-locate@2.0.0:
     resolution: {integrity: sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==}
     engines: {node: '>=4'}
@@ -8425,6 +8584,9 @@ packages:
     resolution: {integrity: sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==}
     engines: {node: '>=0.10.0'}
 
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
   patch-package@8.0.1:
     resolution: {integrity: sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==}
     engines: {node: '>=14', npm: '>5'}
@@ -8453,6 +8615,10 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
+  path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
+
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
@@ -8478,6 +8644,12 @@ packages:
 
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@1.1.1:
+    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
 
   pathval@2.0.1:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
@@ -8551,6 +8723,9 @@ packages:
   pkg-dir@5.0.0:
     resolution: {integrity: sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==}
     engines: {node: '>=10'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
   platform@1.3.6:
     resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
@@ -8789,6 +8964,9 @@ packages:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
     engines: {node: '>=10'}
 
+  psl@1.15.0:
+    resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
+
   public-encrypt@4.0.3:
     resolution: {integrity: sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==}
 
@@ -8817,6 +8995,9 @@ packages:
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
 
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
+
+  querystringify@2.2.0:
+    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -8856,11 +9037,6 @@ packages:
     peerDependencies:
       react: ^16.8.5 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.5 || ^17.0.0 || ^18.0.0
-
-  react-dom@18.3.1:
-    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
-    peerDependencies:
-      react: ^18.3.1
 
   react-dom@19.2.7:
     resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
@@ -9039,6 +9215,9 @@ packages:
   require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
 
+  requires-port@1.0.0:
+    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+
   resolve-alpn@1.2.1:
     resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
 
@@ -9156,6 +9335,12 @@ packages:
   rope-sequence@1.3.4:
     resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
 
+  rrweb-cssom@0.7.1:
+    resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   run-async@2.4.1:
     resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
     engines: {node: '>=0.12.0'}
@@ -9209,8 +9394,9 @@ packages:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
 
-  scheduler@0.23.2:
-    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -9572,6 +9758,10 @@ packages:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
 
+  strip-final-newline@3.0.0:
+    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
+    engines: {node: '>=12'}
+
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
@@ -9583,6 +9773,9 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strip-literal@2.1.1:
+    resolution: {integrity: sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==}
 
   strip-outer@1.0.1:
     resolution: {integrity: sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==}
@@ -9650,6 +9843,9 @@ packages:
   symbol-observable@4.0.0:
     resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}
     engines: {node: '>=0.10'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   table@6.9.0:
     resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
@@ -9833,12 +10029,20 @@ packages:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
+  tinypool@0.8.4:
+    resolution: {integrity: sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==}
+    engines: {node: '>=14.0.0'}
+
   tinypool@1.1.1:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
 
   tinyrainbow@1.2.0:
     resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@2.2.1:
+    resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
     engines: {node: '>=14.0.0'}
 
   tinyspy@3.0.2:
@@ -9885,11 +10089,19 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  tough-cookie@4.1.4:
+    resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
+    engines: {node: '>=6'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   tr46@1.0.1:
     resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -9915,7 +10127,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
-      '@babel/core': '>=7.0.0-beta.0 <8'
+      '@babel/core': ^7.26.0
       '@jest/transform': ^29.0.0 || ^30.0.0
       '@jest/types': ^29.0.0 || ^30.0.0
       babel-jest: ^29.0.0 || ^30.0.0
@@ -10016,6 +10228,10 @@ packages:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
     engines: {node: '>=4'}
 
+  type-detect@4.1.0:
+    resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
+    engines: {node: '>=4'}
+
   type-fest@0.10.0:
     resolution: {integrity: sha512-EUV9jo4sffrwlg8s0zDhP0T2WD3pru5Xi0+HTE3zTUmBaZNhfkite9PdSJwdXLwPVW0jnAHT56pZHIOYckPEiw==}
     engines: {node: '>=8'}
@@ -10104,6 +10320,9 @@ packages:
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+
   uglify-js@3.19.3:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
     engines: {node: '>=0.8.0'}
@@ -10155,6 +10374,10 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
 
+  universalify@0.2.0:
+    resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
+    engines: {node: '>= 4.0.0'}
+
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
@@ -10190,6 +10413,9 @@ packages:
   url-parse-lax@3.0.0:
     resolution: {integrity: sha512-NjFKA0DidqPa5ciFcSrXnAltTtzz84ogy+NebPvfEgAck0+TNg4UJ4IN+fB7zRZfbgUf0syOo9MDxFkDSMuFaQ==}
     engines: {node: '>=4'}
+
+  url-parse@1.5.10:
+    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
   use-memo-one@1.1.3:
     resolution: {integrity: sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==}
@@ -10253,6 +10479,11 @@ packages:
   varuint-bitcoin@1.1.2:
     resolution: {integrity: sha512-4EVb+w4rx+YfVM32HQX42AbbT7/1f5zwAYhIujKXKk8NQK+JfRVl3pqT3hjNn/L+RstigmGGKVwHA/P0wgITZw==}
 
+  vite-node@1.6.1:
+    resolution: {integrity: sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
   vite-node@2.1.9:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -10261,7 +10492,7 @@ packages:
   vite-plugin-babel-compiler@0.3.0:
     resolution: {integrity: sha512-X2IUJZorGRnZPERRhPKfGzzV+ycD/Whsl8mhSKixm1Ypmvo9DEGjWigRhn5iH2CsOiJGOCmQxBYg+BZkFpDEZw==}
     peerDependencies:
-      '@babel/core': ^7.17.9
+      '@babel/core': ^7.26.0
       vite: ^3.1.0
 
   vite-plugin-bundle@1.1.1:
@@ -10373,6 +10604,31 @@ packages:
     resolution: {integrity: sha512-twpPZ/6UnDR8X0Nmj767KwKhXlTQQM9V/J1i2BP9ryO29/w4hpxBfEum6nvfpNhJ4H3h+cIhwzAK/e9crZ6HEQ==}
     hasBin: true
 
+  vitest@1.6.1:
+    resolution: {integrity: sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 1.6.1
+      '@vitest/ui': 1.6.1
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vitest@2.1.9:
     resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -10468,6 +10724,10 @@ packages:
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
 
@@ -10492,6 +10752,10 @@ packages:
   webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
 
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
   webpack-sources@3.5.0:
     resolution: {integrity: sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==}
     engines: {node: '>=10.13.0'}
@@ -10505,6 +10769,19 @@ packages:
     peerDependenciesMeta:
       webpack-cli:
         optional: true
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -10681,6 +10958,10 @@ packages:
     resolution: {integrity: sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==}
     hasBin: true
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
   xml2js@0.5.0:
     resolution: {integrity: sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==}
     engines: {node: '>=4.0.0'}
@@ -10696,6 +10977,9 @@ packages:
   xmlbuilder@15.1.1:
     resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
     engines: {node: '>=8.0'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   xpath@0.0.32:
     resolution: {integrity: sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw==}
@@ -10773,6 +11057,10 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yocto-queue@1.2.2:
+    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
+    engines: {node: '>=12.20'}
 
   zen-observable-ts@1.2.5:
     resolution: {integrity: sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==}
@@ -10925,6 +11213,14 @@ snapshots:
       zen-observable-ts: 1.2.5
     optionalDependencies:
       react: 18.3.1
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
 
   '@babel/code-frame@7.12.11':
     dependencies:
@@ -11758,7 +12054,7 @@ snapshots:
       '@ionic/utils-subprocess': 2.1.14
       '@ionic/utils-terminal': 2.3.5
       commander: 9.5.0
-      debug: 4.3.4
+      debug: 4.4.3
       env-paths: 2.2.1
       kleur: 4.1.5
       native-run: 2.0.3
@@ -11815,17 +12111,17 @@ snapshots:
     dependencies:
       '@capacitor/core': 7.6.6
 
-  '@coasys/ad4m-connect@0.13.0-localhost-wildcard-1':
+  '@coasys/ad4m-connect@0.13.0-test-9':
     dependencies:
       '@undecaf/barcode-detector-polyfill': 0.9.23
       '@undecaf/zbar-wasm': 0.9.16
       auto-bind: 5.0.1
       lit: 2.8.0
 
-  '@coasys/ad4m-react-hooks@0.13.0-test-8(preact@10.29.2)(react@18.3.1)':
+  '@coasys/ad4m-react-hooks@0.13.0-test-9(preact@10.29.2)(react@18.3.1)':
     dependencies:
-      '@coasys/ad4m': 0.13.0-test-8
-      '@coasys/hooks-helpers': 0.13.0-test-8
+      '@coasys/ad4m': 0.13.0-test-9
+      '@coasys/hooks-helpers': 0.13.0-test-9
       '@types/react': 18.3.30
       '@types/react-dom': 18.3.7(@types/react@18.3.30)
       preact: 10.29.2
@@ -11834,16 +12130,16 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@coasys/ad4m-vue-hooks@0.13.0-test-8(vue@3.5.35(typescript@5.9.3))':
+  '@coasys/ad4m-vue-hooks@0.13.0-test-9(vue@3.5.35(typescript@5.9.3))':
     dependencies:
-      '@coasys/ad4m': 0.13.0-test-8
-      '@coasys/hooks-helpers': 0.13.0-test-8
+      '@coasys/ad4m': 0.13.0-test-9
+      '@coasys/hooks-helpers': 0.13.0-test-9
       vue: 3.5.35(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@coasys/ad4m@0.13.0-test-8':
+  '@coasys/ad4m@0.13.0-test-9':
     dependencies:
       '@holochain/client': 0.16.0
       base64-js: 1.5.1
@@ -11852,9 +12148,9 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@coasys/hooks-helpers@0.13.0-test-8':
+  '@coasys/hooks-helpers@0.13.0-test-9':
     dependencies:
-      '@coasys/ad4m': 0.13.0-test-8
+      '@coasys/ad4m': 0.13.0-test-9
       uuid: 9.0.1
     transitivePeerDependencies:
       - bufferutil
@@ -11961,6 +12257,26 @@ snapshots:
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@docsearch/css@3.9.0': {}
 
@@ -12611,7 +12927,7 @@ snapshots:
 
   '@ionic/utils-array@2.1.6':
     dependencies:
-      debug: 4.3.4
+      debug: 4.4.3
       tslib: 2.6.2
     transitivePeerDependencies:
       - supports-color
@@ -12619,7 +12935,7 @@ snapshots:
   '@ionic/utils-fs@3.1.7':
     dependencies:
       '@types/fs-extra': 8.1.5
-      debug: 4.3.4
+      debug: 4.4.3
       fs-extra: 9.1.0
       tslib: 2.6.2
     transitivePeerDependencies:
@@ -12636,7 +12952,7 @@ snapshots:
     dependencies:
       '@ionic/utils-object': 2.1.6
       '@ionic/utils-terminal': 2.3.4
-      debug: 4.3.4
+      debug: 4.4.3
       signal-exit: 3.0.7
       tree-kill: 1.2.2
       tslib: 2.6.2
@@ -12656,7 +12972,7 @@ snapshots:
 
   '@ionic/utils-stream@3.1.6':
     dependencies:
-      debug: 4.3.4
+      debug: 4.4.3
       tslib: 2.6.2
     transitivePeerDependencies:
       - supports-color
@@ -12676,7 +12992,7 @@ snapshots:
       '@ionic/utils-stream': 3.1.6
       '@ionic/utils-terminal': 2.3.4
       cross-spawn: 7.0.6
-      debug: 4.3.4
+      debug: 4.4.3
       tslib: 2.6.2
     transitivePeerDependencies:
       - supports-color
@@ -12697,7 +13013,7 @@ snapshots:
   '@ionic/utils-terminal@2.3.4':
     dependencies:
       '@types/slice-ansi': 4.0.0
-      debug: 4.3.4
+      debug: 4.4.3
       signal-exit: 3.0.7
       slice-ansi: 4.0.0
       string-width: 4.2.3
@@ -14036,6 +14352,12 @@ snapshots:
       vite: 5.4.21(@types/node@25.9.1)(sass@1.100.0)(terser@5.48.0)
       vue: 3.5.35(typescript@5.9.3)
 
+  '@vitest/expect@1.6.1':
+    dependencies:
+      '@vitest/spy': 1.6.1
+      '@vitest/utils': 1.6.1
+      chai: 4.5.0
+
   '@vitest/expect@2.1.9':
     dependencies:
       '@vitest/spy': 2.1.9
@@ -14055,10 +14377,22 @@ snapshots:
     dependencies:
       tinyrainbow: 1.2.0
 
+  '@vitest/runner@1.6.1':
+    dependencies:
+      '@vitest/utils': 1.6.1
+      p-limit: 5.0.0
+      pathe: 1.1.2
+
   '@vitest/runner@2.1.9':
     dependencies:
       '@vitest/utils': 2.1.9
       pathe: 1.1.2
+
+  '@vitest/snapshot@1.6.1':
+    dependencies:
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      pretty-format: 29.7.0
 
   '@vitest/snapshot@2.1.9':
     dependencies:
@@ -14066,9 +14400,20 @@ snapshots:
       magic-string: 0.30.21
       pathe: 1.1.2
 
+  '@vitest/spy@1.6.1':
+    dependencies:
+      tinyspy: 2.2.1
+
   '@vitest/spy@2.1.9':
     dependencies:
       tinyspy: 3.0.2
+
+  '@vitest/utils@1.6.1':
+    dependencies:
+      diff-sequences: 29.6.3
+      estree-walker: 3.0.3
+      loupe: 2.3.7
+      pretty-format: 29.7.0
 
   '@vitest/utils@2.1.9':
     dependencies:
@@ -14394,6 +14739,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  agent-base@7.1.4: {}
+
   agentkeepalive@4.6.0:
     dependencies:
       humanize-ms: 1.2.1
@@ -14611,6 +14958,8 @@ snapshots:
       bn.js: 4.12.3
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
+
+  assertion-error@1.1.0: {}
 
   assertion-error@2.0.1: {}
 
@@ -15099,6 +15448,16 @@ snapshots:
 
   catering@2.1.1: {}
 
+  chai@4.5.0:
+    dependencies:
+      assertion-error: 1.1.0
+      check-error: 1.0.3
+      deep-eql: 4.1.4
+      get-func-name: 2.0.2
+      loupe: 2.3.7
+      pathval: 1.1.1
+      type-detect: 4.1.0
+
   chai@5.3.3:
     dependencies:
       assertion-error: 2.0.1
@@ -15129,6 +15488,10 @@ snapshots:
   char-regex@1.0.2: {}
 
   chardet@0.7.0: {}
+
+  check-error@1.0.3:
+    dependencies:
+      get-func-name: 2.0.2
 
   check-error@2.1.3: {}
 
@@ -15303,6 +15666,8 @@ snapshots:
   compare-version@0.1.2: {}
 
   concat-map@0.0.1: {}
+
+  confbox@0.1.8: {}
 
   config-chain@1.1.13:
     dependencies:
@@ -15565,6 +15930,11 @@ snapshots:
 
   cssesc@3.0.0: {}
 
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
+
   csstype@3.2.3: {}
 
   d3-array@3.2.4:
@@ -15739,6 +16109,11 @@ snapshots:
     dependencies:
       accessor-fn: 1.5.3
 
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+
   data-view-buffer@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -15790,6 +16165,8 @@ snapshots:
 
   decamelize@1.2.0: {}
 
+  decimal.js@10.6.0: {}
+
   decompress-response@3.3.0:
     dependencies:
       mimic-response: 1.0.1
@@ -15803,6 +16180,10 @@ snapshots:
       mimic-response: 3.1.0
 
   dedent@1.7.2: {}
+
+  deep-eql@4.1.4:
+    dependencies:
+      type-detect: 4.1.0
 
   deep-eql@5.0.2: {}
 
@@ -16177,6 +16558,8 @@ snapshots:
   entities@2.2.0: {}
 
   entities@4.5.0: {}
+
+  entities@6.0.1: {}
 
   entities@7.0.1: {}
 
@@ -16856,6 +17239,18 @@ snapshots:
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
 
+  execa@8.0.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 8.0.1
+      human-signals: 5.0.0
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.3.0
+      onetime: 6.0.0
+      signal-exit: 4.1.0
+      strip-final-newline: 3.0.0
+
   exit@0.1.2: {}
 
   expand-template@2.0.3: {}
@@ -17153,6 +17548,8 @@ snapshots:
       tiny-each-async: 2.0.3
     optional: true
 
+  get-func-name@2.0.2: {}
+
   get-installed-path@2.1.1:
     dependencies:
       global-modules: 1.0.0
@@ -17206,6 +17603,8 @@ snapshots:
       pump: 3.0.4
 
   get-stream@6.0.1: {}
+
+  get-stream@8.0.1: {}
 
   get-symbol-description@1.1.0:
     dependencies:
@@ -17504,6 +17903,10 @@ snapshots:
 
   howler@2.2.4: {}
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   html-escaper@2.0.2: {}
 
   html-minifier@4.0.0:
@@ -17526,6 +17929,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   http2-wrapper@1.0.3:
     dependencies:
       quick-lru: 5.1.1
@@ -17538,7 +17948,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   human-signals@2.1.0: {}
+
+  human-signals@5.0.0: {}
 
   humanize-ms@1.2.1:
     dependencies:
@@ -17804,6 +18223,8 @@ snapshots:
   is-path-inside@3.0.3: {}
 
   is-plain-obj@1.1.0: {}
+
+  is-potential-custom-element-name@1.0.1: {}
 
   is-promise@2.2.2: {}
 
@@ -18306,12 +18727,42 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-tokens@9.0.1: {}
+
   js-yaml@3.14.2:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
   jschardet@3.1.4: {}
+
+  jsdom@24.1.3:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      form-data: 4.0.5
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.24
+      parse5: 7.3.0
+      rrweb-cssom: 0.7.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 4.1.4
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.21.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   jsesc@3.1.0: {}
 
@@ -18590,6 +19041,11 @@ snapshots:
       emojis-list: 3.0.0
       json5: 2.2.3
 
+  local-pkg@0.5.1:
+    dependencies:
+      mlly: 1.8.2
+      pkg-types: 1.3.1
+
   locate-path@2.0.0:
     dependencies:
       p-locate: 2.0.0
@@ -18656,6 +19112,10 @@ snapshots:
       js-tokens: 4.0.0
 
   lossless-json@4.3.0: {}
+
+  loupe@2.3.7:
+    dependencies:
+      get-func-name: 2.0.2
 
   loupe@3.2.1: {}
 
@@ -18824,6 +19284,8 @@ snapshots:
 
   mimic-fn@3.1.0: {}
 
+  mimic-fn@4.0.0: {}
+
   mimic-response@1.0.1: {}
 
   mimic-response@2.1.0: {}
@@ -18931,6 +19393,13 @@ snapshots:
     optional: true
 
   mkdirp@1.0.4: {}
+
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.16.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.4
 
   modify-values@1.0.1: {}
 
@@ -19170,11 +19639,17 @@ snapshots:
     dependencies:
       path-key: 3.1.1
 
+  npm-run-path@5.3.0:
+    dependencies:
+      path-key: 4.0.0
+
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
 
   number-is-nan@1.0.1: {}
+
+  nwsapi@2.2.24: {}
 
   object-assign@4.1.1: {}
 
@@ -19240,6 +19715,10 @@ snapshots:
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
+
+  onetime@6.0.0:
+    dependencies:
+      mimic-fn: 4.0.0
 
   onnx-proto@4.0.4:
     dependencies:
@@ -19359,6 +19838,10 @@ snapshots:
     dependencies:
       yocto-queue: 0.1.0
 
+  p-limit@5.0.0:
+    dependencies:
+      yocto-queue: 1.2.2
+
   p-locate@2.0.0:
     dependencies:
       p-limit: 1.3.0
@@ -19462,6 +19945,10 @@ snapshots:
 
   parse-passwd@1.0.0: {}
 
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
   patch-package@8.0.1:
     dependencies:
       '@yarnpkg/lockfile': 1.1.0
@@ -19491,6 +19978,8 @@ snapshots:
 
   path-key@3.1.1: {}
 
+  path-key@4.0.0: {}
+
   path-parse@1.0.7: {}
 
   path-scurry@1.11.1:
@@ -19514,6 +20003,10 @@ snapshots:
   path-type@4.0.0: {}
 
   pathe@1.1.2: {}
+
+  pathe@2.0.3: {}
+
+  pathval@1.1.1: {}
 
   pathval@2.0.1: {}
 
@@ -19564,6 +20057,12 @@ snapshots:
   pkg-dir@5.0.0:
     dependencies:
       find-up: 5.0.0
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
 
   platform@1.3.6: {}
 
@@ -19847,6 +20346,10 @@ snapshots:
 
   proxy-from-env@2.1.0: {}
 
+  psl@1.15.0:
+    dependencies:
+      punycode: 2.3.1
+
   public-encrypt@4.0.3:
     dependencies:
       bn.js: 4.12.3
@@ -19872,6 +20375,8 @@ snapshots:
   pure-rand@6.1.0: {}
 
   q@1.5.1: {}
+
+  querystringify@2.2.0: {}
 
   queue-microtask@1.2.3: {}
 
@@ -19907,25 +20412,19 @@ snapshots:
     dependencies:
       cross-spawn-windows-exe: 1.2.0
 
-  react-beautiful-dnd@13.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-beautiful-dnd@13.1.1(react-dom@19.2.7(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.29.7
       css-box-model: 1.2.1
       memoize-one: 5.2.1
       raf-schd: 4.0.3
       react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      react-redux: 7.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-dom: 19.2.7(react@18.3.1)
+      react-redux: 7.2.9(react-dom@19.2.7(react@18.3.1))(react@18.3.1)
       redux: 4.2.1
       use-memo-one: 1.1.3(react@18.3.1)
     transitivePeerDependencies:
       - react-native
-
-  react-dom@18.3.1(react@18.3.1):
-    dependencies:
-      loose-envify: 1.4.0
-      react: 18.3.1
-      scheduler: 0.23.2
 
   react-dom@19.2.7(react@18.3.1):
     dependencies:
@@ -19947,7 +20446,7 @@ snapshots:
 
   react-is@18.3.1: {}
 
-  react-redux@7.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-redux@7.2.9(react-dom@19.2.7(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.29.7
       '@types/react-redux': 7.1.34
@@ -19957,7 +20456,7 @@ snapshots:
       react: 18.3.1
       react-is: 17.0.2
     optionalDependencies:
-      react-dom: 18.3.1(react@18.3.1)
+      react-dom: 19.2.7(react@18.3.1)
 
   react-virtuoso@3.1.5(react-dom@19.2.7(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -20127,6 +20626,8 @@ snapshots:
 
   require-main-filename@2.0.0: {}
 
+  requires-port@1.0.0: {}
+
   resolve-alpn@1.2.1: {}
 
   resolve-cwd@3.0.0:
@@ -20272,6 +20773,10 @@ snapshots:
 
   rope-sequence@1.3.4: {}
 
+  rrweb-cssom@0.7.1: {}
+
+  rrweb-cssom@0.8.0: {}
+
   run-async@2.4.1: {}
 
   run-parallel-limit@1.1.0:
@@ -20329,9 +20834,9 @@ snapshots:
 
   sax@1.6.0: {}
 
-  scheduler@0.23.2:
+  saxes@6.0.0:
     dependencies:
-      loose-envify: 1.4.0
+      xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
@@ -20769,6 +21274,8 @@ snapshots:
 
   strip-final-newline@2.0.0: {}
 
+  strip-final-newline@3.0.0: {}
+
   strip-indent@3.0.0:
     dependencies:
       min-indent: 1.0.1
@@ -20776,6 +21283,10 @@ snapshots:
   strip-json-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
+
+  strip-literal@2.1.1:
+    dependencies:
+      js-tokens: 9.0.1
 
   strip-outer@1.0.1:
     dependencies:
@@ -20835,6 +21346,8 @@ snapshots:
   symbol-observable@3.0.0: {}
 
   symbol-observable@4.0.0: {}
+
+  symbol-tree@3.2.4: {}
 
   table@6.9.0:
     dependencies:
@@ -21044,9 +21557,13 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinypool@0.8.4: {}
+
   tinypool@1.1.1: {}
 
   tinyrainbow@1.2.0: {}
+
+  tinyspy@2.2.1: {}
 
   tinyspy@3.0.2: {}
 
@@ -21089,9 +21606,20 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  tough-cookie@4.1.4:
+    dependencies:
+      psl: 1.15.0
+      punycode: 2.3.1
+      universalify: 0.2.0
+      url-parse: 1.5.10
+
   tr46@0.0.3: {}
 
   tr46@1.0.1:
+    dependencies:
+      punycode: 2.3.1
+
+  tr46@5.1.1:
     dependencies:
       punycode: 2.3.1
 
@@ -21228,6 +21756,8 @@ snapshots:
 
   type-detect@4.0.8: {}
 
+  type-detect@4.1.0: {}
+
   type-fest@0.10.0: {}
 
   type-fest@0.13.1:
@@ -21300,6 +21830,8 @@ snapshots:
 
   uc.micro@2.1.0: {}
 
+  ufo@1.6.4: {}
+
   uglify-js@3.19.3: {}
 
   unbox-primitive@1.1.0:
@@ -21342,6 +21874,8 @@ snapshots:
 
   universalify@0.1.2: {}
 
+  universalify@0.2.0: {}
+
   universalify@2.0.1: {}
 
   unorm@1.6.0:
@@ -21383,6 +21917,11 @@ snapshots:
   url-parse-lax@3.0.0:
     dependencies:
       prepend-http: 2.0.0
+
+  url-parse@1.5.10:
+    dependencies:
+      querystringify: 2.2.0
+      requires-port: 1.0.0
 
   use-memo-one@1.1.3(react@18.3.1):
     dependencies:
@@ -21431,6 +21970,24 @@ snapshots:
   varuint-bitcoin@1.1.2:
     dependencies:
       safe-buffer: 5.2.1
+
+  vite-node@1.6.1(@types/node@25.9.1)(sass@1.100.0)(terser@5.48.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      vite: 5.4.21(@types/node@25.9.1)(sass@1.100.0)(terser@5.48.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   vite-node@2.1.9(@types/node@25.9.1)(sass@1.100.0)(terser@5.48.0):
     dependencies:
@@ -21573,7 +22130,42 @@ snapshots:
       - terser
       - typescript
 
-  vitest@2.1.9(@types/node@25.9.1)(sass@1.100.0)(terser@5.48.0):
+  vitest@1.6.1(@types/node@25.9.1)(jsdom@24.1.3)(sass@1.100.0)(terser@5.48.0):
+    dependencies:
+      '@vitest/expect': 1.6.1
+      '@vitest/runner': 1.6.1
+      '@vitest/snapshot': 1.6.1
+      '@vitest/spy': 1.6.1
+      '@vitest/utils': 1.6.1
+      acorn-walk: 8.3.5
+      chai: 4.5.0
+      debug: 4.4.3
+      execa: 8.0.1
+      local-pkg: 0.5.1
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      std-env: 3.10.0
+      strip-literal: 2.1.1
+      tinybench: 2.9.0
+      tinypool: 0.8.4
+      vite: 5.4.21(@types/node@25.9.1)(sass@1.100.0)(terser@5.48.0)
+      vite-node: 1.6.1(@types/node@25.9.1)(sass@1.100.0)(terser@5.48.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.9.1
+      jsdom: 24.1.3
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vitest@2.1.9(@types/node@25.9.1)(jsdom@24.1.3)(sass@1.100.0)(terser@5.48.0):
     dependencies:
       '@vitest/expect': 2.1.9
       '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@25.9.1)(sass@1.100.0)(terser@5.48.0))
@@ -21597,6 +22189,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.1
+      jsdom: 24.1.3
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -21680,6 +22273,10 @@ snapshots:
 
   w3c-keyname@2.2.8: {}
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   walker@1.0.8:
     dependencies:
       makeerror: 1.0.12
@@ -21705,6 +22302,8 @@ snapshots:
   webidl-conversions@3.0.1: {}
 
   webidl-conversions@4.0.2: {}
+
+  webidl-conversions@7.0.0: {}
 
   webpack-sources@3.5.0: {}
 
@@ -21746,6 +22345,17 @@ snapshots:
       - lightningcss
       - postcss
       - uglify-js
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   whatwg-url@5.0.0:
     dependencies:
@@ -22000,6 +22610,8 @@ snapshots:
     dependencies:
       sax: 1.6.0
 
+  xml-name-validator@5.0.0: {}
+
   xml2js@0.5.0:
     dependencies:
       sax: 1.6.0
@@ -22013,6 +22625,8 @@ snapshots:
   xmlbuilder@11.0.1: {}
 
   xmlbuilder@15.1.1: {}
+
+  xmlchars@2.2.0: {}
 
   xpath@0.0.32: {}
 
@@ -22093,6 +22707,8 @@ snapshots:
   yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  yocto-queue@1.2.2: {}
 
   zen-observable-ts@1.2.5:
     dependencies:


### PR DESCRIPTION
## Summary

Wires Flux's `SfuManager` to the renegotiation pipeline shipped on `coasys/ad4m#712`:

- `subscribeCallRenegotiationOffer` is now consumed via the SDK's typed surface. Payload aligned to `crate::sfu::types::SfuCallRenegotiationOffer` (`{targetDid, neighbourhoodUrl, roomName, sdpOffer}`).
- Defensive double-filter on `neighbourhoodUrl` + `roomName` in the subscriber so any future events_ws fanout regression can't push a stale renegotiation into the wrong room.
- Unsubscribe handle stored as `renegotiationUnsubscribe` and released in `leave()` so listeners don't leak across join/leave cycles.
- `SfuManager` constructor takes an optional `SfuConfig` — when present, its `iceServers` are authoritative over the per-app `iceConfig`, so the SFU host can rotate TURN creds.

## Dependencies

- ad4m `coasys/ad4m#712` must be merged first — exposes `NeighbourhoodProxy.subscribeCallRenegotiationOffer` and the renegotiation payload shape.

## Test plan

- [ ] Flux package CI green
- [ ] Join an SFU room as user-A, then user-B joins → user-A's RTCPeerConnection receives the new track within ~1s
- [ ] Leave + rejoin → no stray renegotiation events (unsubscribe ran)

🤖 Generated with [Claude Code](https://claude.com/claude-code)