### PR TITLE
Export with flat / grouped options

### DIFF
--- a/app/src/components/conversation/timeline/TimelineColumn.vue
+++ b/app/src/components/conversation/timeline/TimelineColumn.vue
@@ -23,26 +23,26 @@
       </j-flex>
 
       <j-flex a="center" gap="300">
-        <j-button
-          v-if="conversations.length > 0"
-          size="sm"
-          variant="ghost"
-          :loading="exporting"
-          @click="exportTranscript"
-        >
-          <j-icon name="download" slot="start" />
-          Export
-        </j-button>
-
-        <j-button
-          size="sm"
-          variant="ghost"
-          :loading="exportingFlat"
-          @click="exportChannelMessagesFlat"
-        >
-          <j-icon name="download" slot="start" />
-          Export messages
-        </j-button>
+        <j-popover placement="bottom-end">
+          <j-button
+            v-if="conversations.length > 0"
+            size="sm"
+            variant="ghost"
+            :loading="exporting || exportingFlat"
+            slot="trigger"
+          >
+            <j-icon name="download" slot="start" />
+            Export
+          </j-button>
+          <j-menu slot="content">
+            <j-menu-item @click="() => exportTranscript()">
+              <j-text nomargin>With summaries and sub-groups</j-text>
+            </j-menu-item>
+            <j-menu-item @click="() => exportChannelMessagesFlat()">
+              <j-text nomargin>Flat channel messages</j-text>
+            </j-menu-item>
+          </j-menu>
+        </j-popover>
       </j-flex>
     </j-flex>
 

--- a/app/src/components/conversation/timeline/TimelineColumn.vue
+++ b/app/src/components/conversation/timeline/TimelineColumn.vue
@@ -33,6 +33,16 @@
           <j-icon name="download" slot="start" />
           Export
         </j-button>
+
+        <j-button
+          size="sm"
+          variant="ghost"
+          :loading="exportingFlat"
+          @click="exportChannelMessagesFlat"
+        >
+          <j-icon name="download" slot="start" />
+          Export messages
+        </j-button>
       </j-flex>
     </j-flex>
 
@@ -117,6 +127,7 @@ import Avatar from '@/components/conversation/avatar/Avatar.vue';
 import TimelineBlock from '@/components/conversation/timeline/TimelineBlock.vue';
 import ProgressBar from '@/components/progress-bar/ProgressBar.vue';
 import { useCommunityService } from '@/composables/useCommunityService';
+import { getCachedAgentProfile } from '@/utils/userProfileCache';
 import { llmProcessingSteps, useAiStore, useAppStore } from '@/stores';
 import { closeMenu } from '@/utils/helperFunctions';
 import { restoreChannelPrefix, stripNeighbourhoodPrefix } from '@/utils/routeUtils';
@@ -158,6 +169,78 @@ const linkAddedTimeout = ref<any>(null);
 const linkUpdatesQueued = ref<any>(null);
 const loading = ref(true);
 const exporting = ref(false);
+const exportingFlat = ref(false);
+
+function stripHtml(html: string): string {
+  return html?.replace(/<[^>]*>/g, '')?.trim() || '';
+}
+
+function formatTimestamp(ts: string): string {
+  try {
+    const date = new Date(ts);
+    return date.toISOString().replace('T', ' ').replace(/\.\d+Z$/, ' UTC');
+  } catch {
+    return ts;
+  }
+}
+
+async function exportChannelMessagesFlat() {
+  if (exportingFlat.value || !appStore.ad4mClient) return;
+  exportingFlat.value = true;
+  try {
+    const channel = new Channel(perspective, channelUrl);
+    const items = await channel.allItems();
+    if (!items || items.length === 0) {
+      exportingFlat.value = false;
+      return;
+    }
+
+    const itemsWithNames = await Promise.all(
+      items.map(async (item) => {
+        const profile = await getCachedAgentProfile(item.author, appStore.ad4mClient);
+        const authorName = profile.givenName || profile.username || item.author?.slice(0, 16) || 'Unknown';
+        return { ...item, authorName };
+      }),
+    );
+
+    const sorted = [...itemsWithNames].sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+
+    const lines: string[] = [];
+    lines.push('# Channel messages');
+    lines.push('');
+
+    for (const item of sorted) {
+      const text = stripHtml(item.text);
+      if (!text) continue;
+      const time = formatTimestamp(item.timestamp);
+      lines.push(`**${item.authorName}** _(${time})_`);
+      lines.push(text);
+      lines.push('');
+    }
+
+    const fullMarkdown = lines.join('\n');
+
+    try {
+      await navigator.clipboard.writeText(fullMarkdown);
+    } catch (clipboardError) {
+      console.warn('Clipboard write failed:', clipboardError);
+    }
+
+    const blob = new Blob([fullMarkdown], { type: 'text/markdown' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `channel-messages-${new Date().toISOString().slice(0, 10)}.md`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  } catch (error) {
+    console.error('Failed to export flat channel messages:', error);
+  } finally {
+    exportingFlat.value = false;
+  }
+}
 
 async function exportTranscript() {
   if (exporting.value || conversations.value.length === 0 || !appStore.ad4mClient) return;

--- a/packages/api/src/channel/index.ts
+++ b/packages/api/src/channel/index.ts
@@ -64,6 +64,58 @@ export class Channel extends Ad4mModel {
   @HasMany(() => Post)
   posts: Post[] = [];
 
+  async allItems(): Promise<SynergyItem[]> {
+    // Get all items (messages, posts, tasks) in the channel
+    try {
+      const surrealQuery = `
+        SELECT
+          out.uri AS id,
+          author,
+          timestamp,
+          out->link[WHERE predicate = 'flux://entry_type'][0].out.uri AS type,
+          fn::parse_literal(out->link[WHERE predicate = 'flux://body'][0].out.uri) AS messageBody,
+          fn::parse_literal(out->link[WHERE predicate = 'flux://title'][0].out.uri) AS postTitle,
+          fn::parse_literal(out->link[WHERE predicate = 'flux://name'][0].out.uri) AS taskName
+        FROM link
+        WHERE in.uri = '${this.id}'
+          AND predicate = 'ad4m://has_child'
+          AND out->link[WHERE predicate = 'flux://entry_type'][0].out.uri
+              IN ['flux://has_message', 'flux://has_post', 'flux://has_task']
+        ORDER BY timestamp ASC
+      `;
+
+      const surrealResult = await this.perspective.querySurrealDB(surrealQuery);
+
+      return (surrealResult || []).map((item: any) => {
+        let text = '';
+        let type = '';
+
+        if (item.type === 'flux://has_message') {
+          text = item.messageBody || '';
+          type = 'Message';
+        } else if (item.type === 'flux://has_post') {
+          text = item.postTitle || '';
+          type = 'Post';
+        } else if (item.type === 'flux://has_task') {
+          text = item.taskName || '';
+          type = 'Task';
+        }
+
+        return {
+          id: item.id,
+          author: item.author,
+          timestamp: new Date(item.timestamp).toISOString(),
+          text,
+          type,
+          icon: icons[type] ? icons[type] : 'question',
+        };
+      });
+    } catch (error) {
+      console.error('Error getting all channel items:', error);
+      return [];
+    }
+  }
+
   async unprocessedItems(): Promise<SynergyItem[]> {
     // Get all unprocessed items in the channel
     try {


### PR DESCRIPTION
Exporting conversations can now be done as either:
- with summary and sub-groups from the LLM procession (as before)
- or just flat message list (new - for other agents/LLMs to do different processing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Replaced single export button with menu-driven export control offering two distinct export modes.
  * Added "Flat channel messages" export functionality that exports all messages with author names and timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->