### PR TITLE
Fix: Sort subgroups by content timestamp instead of link creation time

### DIFF
--- a/packages/api/src/conversation/index.ts
+++ b/packages/api/src/conversation/index.ts
@@ -569,6 +569,13 @@ export class Conversation extends Ad4mModel {
       });
     }
 
+    // Sort sections by earliest item timestamp (content time, not link creation time)
+    sections.sort((a, b) => {
+      const aTime = a.items.length > 0 ? new Date(a.items[0].timestamp).getTime() : 0;
+      const bTime = b.items.length > 0 ? new Date(b.items[0].timestamp).getTime() : 0;
+      return aTime - bTime;
+    });
+
     // Resolve unprocessed items author names
     let unprocessedWithNames;
     if (unprocessedItems && unprocessedItems.length > 0) {

--- a/packages/api/src/conversation/index.ts
+++ b/packages/api/src/conversation/index.ts
@@ -118,7 +118,7 @@ export class Conversation extends Ad4mModel {
       const surrealResult = await this.perspective.querySurrealDB(surrealQuery);
 
       // Get timestamps for each subgroup separately
-      return await Promise.all(
+      const subgroups = await Promise.all(
         (surrealResult || []).map(async (subgroup: any) => {
           // Query to get timestamps for items in this subgroup
           // Get creation timestamps from channel→item links, not grouping timestamps from subgroup→item links
@@ -153,6 +153,9 @@ export class Conversation extends Ad4mModel {
           };
         }),
       );
+
+      // Sort by actual content start time, not link creation time
+      return subgroups.sort((a, b) => a.start - b.start);
     } catch (error) {
       console.error('Error getting conversation subgroups:', error);
       return [];


### PR DESCRIPTION
# Fix: Sort subgroups by content timestamp instead of link creation time

## Problem

Subgroups in the timeline and exported transcripts were displayed in the wrong chronological order. The `ad4m://has_child` links connecting conversations to their subgroups are created during LLM processing, and their timestamps reflect **when processing occurred**, not when the underlying messages were sent. This caused subgroups to appear out of order whenever processing order diverged from message chronology.

## Changes

### 1. Timeline display (`subgroupsData()`)

`subgroupsData()` was relying on `ORDER BY timestamp ASC` in the SurrealQL query, which sorted by link creation time. Now the results are fetched first, then sorted in JS by the computed `start` field — the earliest `channelTimestamp` of items within each subgroup.

### 2. Transcript export (`exportMarkdown()`)

`exportMarkdown()` fetches subgroups via the Ad4m ORM (`@HasMany`), which returns them in link-storage order (also link creation time). After building the `sections` array with resolved items, the sections are now sorted by the earliest item timestamp before being passed to the markdown formatter.

## Files changed

- `packages/api/src/conversation/index.ts`