### PR TITLE
Fix: Prevent concurrent subgroup processing across peers

### DIFF
--- a/app/src/components/conversation/timeline/TimelineColumn.vue
+++ b/app/src/components/conversation/timeline/TimelineColumn.vue
@@ -178,7 +178,10 @@ function stripHtml(html: string): string {
 function formatTimestamp(ts: string): string {
   try {
     const date = new Date(ts);
-    return date.toISOString().replace('T', ' ').replace(/\.\d+Z$/, ' UTC');
+    return date
+      .toISOString()
+      .replace('T', ' ')
+      .replace(/\.\d+Z$/, ' UTC');
   } catch {
     return ts;
   }
@@ -319,7 +322,7 @@ async function getData(firstRun?: boolean): Promise<void> {
 
     // If this is not the first run and AI is enabled, check if we should process tasks
     if (firstRun || !aiEnabled.value) return;
-    const shouldProcess = await aiStore.checkIfWeShouldProcessTask(newUnprocessedItems, signallingService);
+    const shouldProcess = await aiStore.checkIfWeShouldProcessTask(newUnprocessedItems, signallingService, channelUrl);
     if (shouldProcess) {
       const channel = new Channel(perspective, channelUrl);
       aiStore.addTasksToProcessingQueue([{ communityId: perspective.sharedUrl!, channel }]);

--- a/app/src/stores/aiStore.ts
+++ b/app/src/stores/aiStore.ts
@@ -43,6 +43,7 @@ export const llmProcessingSteps = [
 export const MIN_ITEMS_TO_PROCESS = 5;
 export const MAX_ITEMS_TO_PROCESS = 10;
 export const PROCESSING_ITEMS_DELAY = 3;
+export const PROCESSING_STALE_TIMEOUT = 5 * 60 * 1000; // 5 minutes
 
 export type ProcessingQueueItem = { communityId: string; channel: Partial<Channel> };
 
@@ -141,7 +142,27 @@ export const useAiStore = defineStore(
       return checkItemsForResponsibility(signallingService, items, increment + 1);
     }
 
-    async function checkIfWeShouldProcessTask(unprocessedItems: SynergyItem[], signallingService: SignallingService) {
+    function isAnotherPeerProcessingChannel(signallingService: SignallingService, channelId: string): boolean {
+      const now = Date.now();
+      const agents = signallingService.agents.value;
+      if (!agents) return false;
+      return Object.entries(agents).some(([did, state]) => {
+        if (did === me.value.did) return false;
+        if (!state.processing || state.processing.channelId !== channelId) return false;
+        // Ignore stale processing states (peer may have crashed/disconnected)
+        const age = now - state.lastUpdate;
+        return age < PROCESSING_STALE_TIMEOUT;
+      });
+    }
+
+    async function checkIfWeShouldProcessTask(
+      unprocessedItems: SynergyItem[],
+      signallingService: SignallingService,
+      channelId: string,
+    ) {
+      // Skip if another peer is already processing this channel
+      if (isAnotherPeerProcessingChannel(signallingService, channelId)) return false;
+
       // Skip if not enough unprocessed items
       const enoughItems = unprocessedItems.length >= MIN_ITEMS_TO_PROCESS + PROCESSING_ITEMS_DELAY;
       if (!enoughItems) return false;
@@ -163,8 +184,13 @@ export const useAiStore = defineStore(
       const tasks = await Promise.all(
         unref(communityService.recentConversationsWithAgents).map(async (conversationData) => {
           if (!conversationData.channel) return null;
-          const unprocessedItems = await toRaw(conversationData.channel).unprocessedItems();
-          const shouldProcess = await checkIfWeShouldProcessTask(unprocessedItems, communityService.signallingService);
+          const rawChannel = toRaw(conversationData.channel);
+          const unprocessedItems = await rawChannel.unprocessedItems();
+          const shouldProcess = await checkIfWeShouldProcessTask(
+            unprocessedItems,
+            communityService.signallingService,
+            rawChannel.id!,
+          );
           return shouldProcess ? { communityId, channel: conversationData.channel } : null;
         }),
       );
@@ -238,6 +264,13 @@ export const useAiStore = defineStore(
         // Skip if no items to process (can happen if task was queued but items were processed by another agent)
         if (itemsToProcess.length === 0) {
           console.log('🤖 No items to process, removing task from queue');
+          processingQueue.value.shift();
+          return;
+        }
+
+        // Re-check signalling guard before starting LLM work (another peer may have started since this task was queued)
+        if (isAnotherPeerProcessingChannel(communityService.signallingService, rawChannel.id!)) {
+          console.log('🤖 Another peer is already processing this channel, skipping');
           processingQueue.value.shift();
           return;
         }

--- a/app/src/stores/aiStore.ts
+++ b/app/src/stores/aiStore.ts
@@ -185,11 +185,12 @@ export const useAiStore = defineStore(
         unref(communityService.recentConversationsWithAgents).map(async (conversationData) => {
           if (!conversationData.channel) return null;
           const rawChannel = toRaw(conversationData.channel);
+          if (!rawChannel.id) return null;
           const unprocessedItems = await rawChannel.unprocessedItems();
           const shouldProcess = await checkIfWeShouldProcessTask(
             unprocessedItems,
             communityService.signallingService,
-            rawChannel.id!,
+            rawChannel.id,
           );
           return shouldProcess ? { communityId, channel: conversationData.channel } : null;
         }),


### PR DESCRIPTION
# Fix: Prevent concurrent subgroup processing across peers

## Problem

When multiple peers are online with AI enabled, they can simultaneously process the same unprocessed messages in a channel, resulting in **overlapping subgroups** — the same messages end up assigned to subgroups from both peers.

The existing deterministic responsibility check (`checkItemsForResponsibility`) works correctly when all peers see the same unprocessed items list. However, sync lag between peers causes divergent lists — different first items lead to different walk orders, and both peers independently elect themselves as responsible.

## Solution

Use the **existing signalling service** to prevent concurrent processing. The `ProcessingState` (including `channelId`) is already broadcast to all peers — it just wasn't being consulted before starting processing.

### Changes

- **`isAnotherPeerProcessingChannel()`** — New helper that checks if any other peer's signalling state shows them actively processing the same channel. Includes a 5-minute staleness timeout so crashed/disconnected peers don't block processing indefinitely.

- **`checkIfWeShouldProcessTask()`** — Added `channelId` parameter and signalling guard as the first check, before the existing responsibility logic.

- **`processesNextTask()`** — Added a re-check of the signalling guard right before starting LLM work, covering the window between a task being queued and actually starting.

- **Call sites updated** — `TimelineColumn.vue` and `findProcessingTasksInCommunity()` now pass the channel ID.

### Files changed

| File | Change |
|------|--------|
| `app/src/stores/aiStore.ts` | Signalling guard + `channelId` param |
| `app/src/components/conversation/timeline/TimelineColumn.vue` | Pass `channelUrl` to guard |

### Limitations

- **Fully offline peers** — If two peers can't reach each other via signalling, they can't see each other's processing state. This is inherent to the signalling approach.
- **Existing duplicates** — This fix prevents future concurrent processing but doesn't clean up items already in multiple subgroups.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coordination of AI task processing across peers to prevent duplicate or conflicting work, including handling of stale processing claims so tasks are not blocked indefinitely.

* **Refactor**
  * Refined timestamp formatting for more consistent, robust display of message times.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->