### PR TITLE
feat: add Dockerfile for static Flux frontend

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+node_modules/
+.git/
+app/dist/
+**/dist/
+.turbo/
+*.log
+.DS_Store
+.env*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Stage 1: Build the static frontend
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY . .
+RUN npm install -g yarn@1.22.22
+RUN yarn install --frozen-lockfile || yarn install
+RUN NODE_OPTIONS='--max-old-space-size=4096' yarn build
+
+# Stage 2: Serve with nginx
+FROM nginx:alpine
+COPY --from=builder /app/app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,16 @@
+server {
+    listen 80;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # SPA fallback
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Cache static assets
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+}


### PR DESCRIPTION
Multi-stage Docker build that compiles Flux into a static SPA served by nginx. Connect to an AD4M executor via ad4m-connect's remote node UI.

## Files added
- `Dockerfile` — multi-stage build (Node 20 builder → nginx:alpine runtime)
- `nginx.conf` — SPA routing with static asset caching
- `.dockerignore` — excludes node_modules, .git, dist, .turbo

## Usage
```bash
docker build -t flux .
docker run -p 8080:80 flux
```