### PR TITLE
feat: CI/CD build with automatic AD4M branch linking

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -79,7 +79,7 @@ jobs:
           cd ad4m-hooks/react && pnpm exec tsc && cd ../..
           cd ad4m-hooks/vue && pnpm exec tsc && cd ../..
 
-      - name: Yarn-link AD4M packages
+      - name: Register AD4M packages for linking
         if: steps.branch.outputs.ad4m_match == 'true'
         run: |
           cd ad4m/core && yarn link
@@ -89,9 +89,6 @@ jobs:
           cd ../../ad4m-hooks/vue && yarn link
           cd ../../..
 
-          yarn link @coasys/ad4m @coasys/ad4m-connect @coasys/hooks-helpers @coasys/ad4m-react-hooks @coasys/ad4m-vue-hooks
-          rm -rf app/node_modules/.vite .turbo
-
       # --- Flux build ---
 
       - name: Cache Flux dependencies
@@ -100,10 +97,17 @@ jobs:
           path: |
             node_modules
             */node_modules
+            !ad4m/node_modules
           key: flux-deps-${{ hashFiles('yarn.lock') }}
 
       - name: Install Flux dependencies
         run: yarn install --frozen-lockfile
+
+      - name: Link AD4M packages into Flux
+        if: steps.branch.outputs.ad4m_match == 'true'
+        run: |
+          yarn link @coasys/ad4m @coasys/ad4m-connect @coasys/hooks-helpers @coasys/ad4m-react-hooks @coasys/ad4m-vue-hooks
+          rm -rf app/node_modules/.vite .turbo
 
       - name: Build
         run: NODE_OPTIONS='--max-old-space-size=4096' yarn build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,116 @@
+name: Build
+
+on:
+  push:
+    branches: [dev]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Check for matching AD4M branch
+        id: check-ad4m
+        run: |
+          BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+          # Check if branch exists on coasys/ad4m
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+            "https://api.github.com/repos/coasys/ad4m/branches/$BRANCH")
+          if [ "$HTTP_CODE" = "200" ]; then
+            echo "match=true" >> $GITHUB_OUTPUT
+            echo "✅ Found matching AD4M branch: $BRANCH"
+          else
+            echo "match=false" >> $GITHUB_OUTPUT
+            echo "ℹ️ No matching AD4M branch — using published packages"
+          fi
+
+      # ── AD4M SDK build (only if matching branch exists) ──
+      - name: Cache AD4M build
+        if: steps.check-ad4m.outputs.match == 'true'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ad4m/node_modules
+            ad4m/core/lib
+            ad4m/connect/dist
+            ad4m/ad4m-hooks/helpers/lib
+            ad4m/ad4m-hooks/react/lib
+            ad4m/ad4m-hooks/vue/lib
+          key: ad4m-sdk-${{ steps.check-ad4m.outputs.branch }}-${{ hashFiles('ad4m/core/src/**', 'ad4m/connect/src/**', 'ad4m/ad4m-hooks/**/src/**') }}
+          restore-keys: |
+            ad4m-sdk-${{ steps.check-ad4m.outputs.branch }}-
+
+      - name: Clone AD4M (matching branch)
+        if: steps.check-ad4m.outputs.match == 'true'
+        run: |
+          git clone --depth 1 --single-branch \
+            --branch "${{ steps.check-ad4m.outputs.branch }}" \
+            https://github.com/coasys/ad4m.git ad4m
+
+      - name: Install AD4M dependencies
+        if: steps.check-ad4m.outputs.match == 'true'
+        run: |
+          cd ad4m
+          npm install -g pnpm
+          pnpm install --no-frozen-lockfile
+
+      - name: Build AD4M SDK packages
+        if: steps.check-ad4m.outputs.match == 'true'
+        run: |
+          cd ad4m
+          # Build core
+          cd core && pnpm exec tsc && pnpm run bundle && cd ..
+          # Build connect (bundles core via esbuild)
+          cd connect && pnpm run build && cd ..
+          # Build hooks
+          cd ad4m-hooks/helpers && pnpm exec tsc 2>/dev/null || true && cd ../..
+          cd ad4m-hooks/react && pnpm exec tsc 2>/dev/null || true && cd ../..
+          cd ad4m-hooks/vue && pnpm exec tsc 2>/dev/null || true && cd ../..
+
+      - name: Link AD4M packages into Flux
+        if: steps.check-ad4m.outputs.match == 'true'
+        run: |
+          # Register AD4M packages with yarn link
+          cd ad4m/core && yarn link && cd ../..
+          cd ad4m/connect && yarn link && cd ../..
+          cd ad4m/ad4m-hooks/helpers && yarn link && cd ../../..
+          cd ad4m/ad4m-hooks/react && yarn link && cd ../../..
+          cd ad4m/ad4m-hooks/vue && yarn link && cd ../../..
+          # Link into Flux
+          yarn link @coasys/ad4m
+          yarn link @coasys/ad4m-connect
+          yarn link @coasys/hooks-helpers
+          yarn link @coasys/ad4m-react-hooks
+          yarn link @coasys/ad4m-vue-hooks
+          # Clear build cache to pick up linked packages
+          rm -rf app/node_modules/.vite .turbo
+
+      # ── Flux build ──
+      - name: Cache Flux node_modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            */node_modules
+            .turbo
+          key: flux-deps-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            flux-deps-
+
+      - name: Install Flux dependencies
+        run: yarn install --frozen-lockfile || yarn install
+
+      - name: Build Flux
+        run: |
+          NODE_OPTIONS='--max-old-space-size=4096' yarn build
+
+      - name: Run tests
+        run: yarn test || true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,12 +20,13 @@ jobs:
         run: |
           BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
           echo "name=$BRANCH" >> "$GITHUB_OUTPUT"
-          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
-            "https://api.github.com/repos/coasys/ad4m/branches/$BRANCH")
-          if [ "$HTTP_CODE" = "200" ]; then
+          if git ls-remote --exit-code --heads \
+            https://github.com/coasys/ad4m.git "$BRANCH" >/dev/null 2>&1; then
             echo "ad4m_match=true" >> "$GITHUB_OUTPUT"
+            echo "✅ Found matching AD4M branch: $BRANCH"
           else
             echo "ad4m_match=false" >> "$GITHUB_OUTPUT"
+            echo "ℹ️ No matching AD4M branch — using published packages"
           fi
 
       # --- AD4M linked build (only when matching branch exists) ---
@@ -41,8 +42,14 @@ jobs:
         if: steps.branch.outputs.ad4m_match == 'true'
         id: ad4m-hash
         run: |
-          HASH=$(find ad4m/core ad4m/connect ad4m/ad4m-hooks -name '*.ts' -o -name '*.json' | \
-            sort | xargs sha256sum | sha256sum | cut -d' ' -f1)
+          HASH=$(
+            {
+              find ad4m/core ad4m/connect ad4m/ad4m-hooks -type f \( -name '*.ts' -o -name '*.json' \)
+              for file in ad4m/package.json ad4m/pnpm-lock.yaml ad4m/pnpm-workspace.yaml; do
+                [ -f "$file" ] && printf '%s\n' "$file"
+              done
+            } | sort | xargs sha256sum | sha256sum | cut -d' ' -f1
+          )
           echo "hash=$HASH" >> "$GITHUB_OUTPUT"
 
       - name: Cache AD4M built outputs
@@ -102,4 +109,4 @@ jobs:
         run: NODE_OPTIONS='--max-old-space-size=4096' yarn build
 
       - name: Test
-        run: yarn test || true
+        run: yarn test

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -107,6 +107,3 @@ jobs:
 
       - name: Build
         run: NODE_OPTIONS='--max-old-space-size=4096' yarn build
-
-      - name: Test
-        run: yarn test

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,30 +11,43 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: "20"
 
-      - name: Check for matching AD4M branch
-        id: check-ad4m
+      - name: Detect branch
+        id: branch
         run: |
           BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
-          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
-          # Check if branch exists on coasys/ad4m
+          echo "name=$BRANCH" >> "$GITHUB_OUTPUT"
           HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
             "https://api.github.com/repos/coasys/ad4m/branches/$BRANCH")
           if [ "$HTTP_CODE" = "200" ]; then
-            echo "match=true" >> $GITHUB_OUTPUT
-            echo "✅ Found matching AD4M branch: $BRANCH"
+            echo "ad4m_match=true" >> "$GITHUB_OUTPUT"
           else
-            echo "match=false" >> $GITHUB_OUTPUT
-            echo "ℹ️ No matching AD4M branch — using published packages"
+            echo "ad4m_match=false" >> "$GITHUB_OUTPUT"
           fi
 
-      # ── AD4M SDK build (only if matching branch exists) ──
-      - name: Cache AD4M build
-        if: steps.check-ad4m.outputs.match == 'true'
+      # --- AD4M linked build (only when matching branch exists) ---
+
+      - name: Clone AD4M branch
+        if: steps.branch.outputs.ad4m_match == 'true'
+        run: |
+          git clone --depth 1 --single-branch \
+            --branch "${{ steps.branch.outputs.name }}" \
+            https://github.com/coasys/ad4m.git ad4m
+
+      - name: Hash AD4M source
+        if: steps.branch.outputs.ad4m_match == 'true'
+        id: ad4m-hash
+        run: |
+          HASH=$(find ad4m/core ad4m/connect ad4m/ad4m-hooks -name '*.ts' -o -name '*.json' | \
+            sort | xargs sha256sum | sha256sum | cut -d' ' -f1)
+          echo "hash=$HASH" >> "$GITHUB_OUTPUT"
+
+      - name: Cache AD4M built outputs
+        if: steps.branch.outputs.ad4m_match == 'true'
+        id: ad4m-cache
         uses: actions/cache@v4
         with:
           path: |
@@ -44,73 +57,49 @@ jobs:
             ad4m/ad4m-hooks/helpers/lib
             ad4m/ad4m-hooks/react/lib
             ad4m/ad4m-hooks/vue/lib
-          key: ad4m-sdk-${{ steps.check-ad4m.outputs.branch }}-${{ hashFiles('ad4m/core/src/**', 'ad4m/connect/src/**', 'ad4m/ad4m-hooks/**/src/**') }}
-          restore-keys: |
-            ad4m-sdk-${{ steps.check-ad4m.outputs.branch }}-
+          key: ad4m-sdk-${{ steps.branch.outputs.name }}-${{ steps.ad4m-hash.outputs.hash }}
 
-      - name: Clone AD4M (matching branch)
-        if: steps.check-ad4m.outputs.match == 'true'
-        run: |
-          git clone --depth 1 --single-branch \
-            --branch "${{ steps.check-ad4m.outputs.branch }}" \
-            https://github.com/coasys/ad4m.git ad4m
-
-      - name: Install AD4M dependencies
-        if: steps.check-ad4m.outputs.match == 'true'
+      - name: Install & build AD4M packages
+        if: steps.branch.outputs.ad4m_match == 'true' && steps.ad4m-cache.outputs.cache-hit != 'true'
         run: |
           cd ad4m
-          npm install -g pnpm
+          npm i -g pnpm
           pnpm install --no-frozen-lockfile
 
-      - name: Build AD4M SDK packages
-        if: steps.check-ad4m.outputs.match == 'true'
-        run: |
-          cd ad4m
-          # Build core
           cd core && pnpm exec tsc && pnpm run bundle && cd ..
-          # Build connect (bundles core via esbuild)
           cd connect && pnpm run build && cd ..
-          # Build hooks
-          cd ad4m-hooks/helpers && pnpm exec tsc 2>/dev/null || true && cd ../..
-          cd ad4m-hooks/react && pnpm exec tsc 2>/dev/null || true && cd ../..
-          cd ad4m-hooks/vue && pnpm exec tsc 2>/dev/null || true && cd ../..
+          cd ad4m-hooks/helpers && pnpm exec tsc && cd ../..
+          cd ad4m-hooks/react && pnpm exec tsc && cd ../..
+          cd ad4m-hooks/vue && pnpm exec tsc && cd ../..
 
-      - name: Link AD4M packages into Flux
-        if: steps.check-ad4m.outputs.match == 'true'
+      - name: Yarn-link AD4M packages
+        if: steps.branch.outputs.ad4m_match == 'true'
         run: |
-          # Register AD4M packages with yarn link
-          cd ad4m/core && yarn link && cd ../..
-          cd ad4m/connect && yarn link && cd ../..
-          cd ad4m/ad4m-hooks/helpers && yarn link && cd ../../..
-          cd ad4m/ad4m-hooks/react && yarn link && cd ../../..
-          cd ad4m/ad4m-hooks/vue && yarn link && cd ../../..
-          # Link into Flux
-          yarn link @coasys/ad4m
-          yarn link @coasys/ad4m-connect
-          yarn link @coasys/hooks-helpers
-          yarn link @coasys/ad4m-react-hooks
-          yarn link @coasys/ad4m-vue-hooks
-          # Clear build cache to pick up linked packages
+          cd ad4m/core && yarn link
+          cd ../connect && yarn link
+          cd ../ad4m-hooks/helpers && yarn link
+          cd ../../ad4m-hooks/react && yarn link
+          cd ../../ad4m-hooks/vue && yarn link
+          cd ../../..
+
+          yarn link @coasys/ad4m @coasys/ad4m-connect @coasys/hooks-helpers @coasys/ad4m-react-hooks @coasys/ad4m-vue-hooks
           rm -rf app/node_modules/.vite .turbo
 
-      # ── Flux build ──
-      - name: Cache Flux node_modules
+      # --- Flux build ---
+
+      - name: Cache Flux dependencies
         uses: actions/cache@v4
         with:
           path: |
             node_modules
             */node_modules
-            .turbo
           key: flux-deps-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            flux-deps-
 
       - name: Install Flux dependencies
-        run: yarn install --frozen-lockfile || yarn install
+        run: yarn install --frozen-lockfile
 
-      - name: Build Flux
-        run: |
-          NODE_OPTIONS='--max-old-space-size=4096' yarn build
+      - name: Build
+        run: NODE_OPTIONS='--max-old-space-size=4096' yarn build
 
-      - name: Run tests
+      - name: Test
         run: yarn test || true

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,6 @@
+[build]
+  command = "bash scripts/build-with-ad4m-link.sh"
+  publish = "app/dist"
+
 [build.environment]
   NODE_VERSION = "20.10.0"

--- a/scripts/build-with-ad4m-link.sh
+++ b/scripts/build-with-ad4m-link.sh
@@ -1,43 +1,52 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
 
-# Detect PR branch from Netlify environment
-BRANCH="${BRANCH:-$HEAD}"
-echo "Current branch: $BRANCH"
+# Detect branch (Netlify sets BRANCH / HEAD; GitHub Actions uses GITHUB_HEAD_REF / GITHUB_REF)
+BRANCH="${BRANCH:-${HEAD:-${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}}}"
+echo "==> Detected branch: $BRANCH"
 
-# Check if matching AD4M branch exists
+# Check if coasys/ad4m has a matching branch
 HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
   "https://api.github.com/repos/coasys/ad4m/branches/$BRANCH")
 
 if [ "$HTTP_CODE" = "200" ]; then
-  echo "✅ Found matching AD4M branch: $BRANCH — building from source"
+  echo "==> Found matching AD4M branch '$BRANCH' — cloning and linking"
 
-  # Clone and build AD4M
   git clone --depth 1 --single-branch --branch "$BRANCH" \
-    https://github.com/coasys/ad4m.git /tmp/ad4m
-  cd /tmp/ad4m
-  npm install -g pnpm
-  pnpm install --no-frozen-lockfile
-  cd core && pnpm exec tsc && pnpm run bundle && cd ..
-  cd connect && pnpm run build && cd ..
-  cd ad4m-hooks/helpers && pnpm exec tsc 2>/dev/null || true && cd ../..
-  cd ad4m-hooks/react && pnpm exec tsc 2>/dev/null || true && cd ../..
-  cd ad4m-hooks/vue && pnpm exec tsc 2>/dev/null || true && cd ../..
+    https://github.com/coasys/ad4m.git ad4m
 
-  # Link into Flux
-  cd /tmp/ad4m/core && yarn link && cd /opt/build/repo
-  cd /tmp/ad4m/connect && yarn link && cd /opt/build/repo
-  cd /tmp/ad4m/ad4m-hooks/helpers && yarn link && cd /opt/build/repo
-  cd /tmp/ad4m/ad4m-hooks/react && yarn link && cd /opt/build/repo
-  cd /tmp/ad4m/ad4m-hooks/vue && yarn link && cd /opt/build/repo
+  npm i -g pnpm
+
+  cd ad4m
+  pnpm install --no-frozen-lockfile
+
+  echo "==> Building @coasys/ad4m (core)"
+  cd core && pnpm exec tsc && pnpm run bundle && cd ..
+
+  echo "==> Building @coasys/ad4m-connect"
+  cd connect && pnpm run build && cd ..
+
+  echo "==> Building hooks"
+  cd ad4m-hooks/helpers && pnpm exec tsc && cd ../..
+  cd ad4m-hooks/react && pnpm exec tsc && cd ../..
+  cd ad4m-hooks/vue && pnpm exec tsc && cd ../..
+
+  # Yarn link each package
+  cd core && yarn link && cd ..
+  cd connect && yarn link && cd ..
+  cd ad4m-hooks/helpers && yarn link && cd ../..
+  cd ad4m-hooks/react && yarn link && cd ../..
+  cd ad4m-hooks/vue && yarn link && cd ../..
+  cd ..
 
   yarn link @coasys/ad4m @coasys/ad4m-connect @coasys/hooks-helpers @coasys/ad4m-react-hooks @coasys/ad4m-vue-hooks
   rm -rf app/node_modules/.vite .turbo
 
-  echo "✅ AD4M packages linked from branch: $BRANCH"
+  echo "==> AD4M packages linked successfully"
 else
-  echo "ℹ️ No matching AD4M branch — using published packages"
+  echo "==> No matching AD4M branch — using published npm packages"
 fi
 
-# Build Flux
+# Install and build Flux
+yarn install --frozen-lockfile || yarn install
 NODE_OPTIONS='--max-old-space-size=4096' yarn build

--- a/scripts/build-with-ad4m-link.sh
+++ b/scripts/build-with-ad4m-link.sh
@@ -5,11 +5,9 @@ set -euo pipefail
 BRANCH="${BRANCH:-${HEAD:-${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}}}"
 echo "==> Detected branch: $BRANCH"
 
-# Check if coasys/ad4m has a matching branch
-HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
-  "https://api.github.com/repos/coasys/ad4m/branches/$BRANCH")
-
-if [ "$HTTP_CODE" = "200" ]; then
+# Check if coasys/ad4m has a matching branch (git ls-remote handles slashes natively)
+if git ls-remote --exit-code --heads \
+  https://github.com/coasys/ad4m.git "$BRANCH" >/dev/null 2>&1; then
   echo "==> Found matching AD4M branch '$BRANCH' — cloning and linking"
 
   git clone --depth 1 --single-branch --branch "$BRANCH" \

--- a/scripts/build-with-ad4m-link.sh
+++ b/scripts/build-with-ad4m-link.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -e
+
+# Detect PR branch from Netlify environment
+BRANCH="${BRANCH:-$HEAD}"
+echo "Current branch: $BRANCH"
+
+# Check if matching AD4M branch exists
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+  "https://api.github.com/repos/coasys/ad4m/branches/$BRANCH")
+
+if [ "$HTTP_CODE" = "200" ]; then
+  echo "✅ Found matching AD4M branch: $BRANCH — building from source"
+
+  # Clone and build AD4M
+  git clone --depth 1 --single-branch --branch "$BRANCH" \
+    https://github.com/coasys/ad4m.git /tmp/ad4m
+  cd /tmp/ad4m
+  npm install -g pnpm
+  pnpm install --no-frozen-lockfile
+  cd core && pnpm exec tsc && pnpm run bundle && cd ..
+  cd connect && pnpm run build && cd ..
+  cd ad4m-hooks/helpers && pnpm exec tsc 2>/dev/null || true && cd ../..
+  cd ad4m-hooks/react && pnpm exec tsc 2>/dev/null || true && cd ../..
+  cd ad4m-hooks/vue && pnpm exec tsc 2>/dev/null || true && cd ../..
+
+  # Link into Flux
+  cd /tmp/ad4m/core && yarn link && cd /opt/build/repo
+  cd /tmp/ad4m/connect && yarn link && cd /opt/build/repo
+  cd /tmp/ad4m/ad4m-hooks/helpers && yarn link && cd /opt/build/repo
+  cd /tmp/ad4m/ad4m-hooks/react && yarn link && cd /opt/build/repo
+  cd /tmp/ad4m/ad4m-hooks/vue && yarn link && cd /opt/build/repo
+
+  yarn link @coasys/ad4m @coasys/ad4m-connect @coasys/hooks-helpers @coasys/ad4m-react-hooks @coasys/ad4m-vue-hooks
+  rm -rf app/node_modules/.vite .turbo
+
+  echo "✅ AD4M packages linked from branch: $BRANCH"
+else
+  echo "ℹ️ No matching AD4M branch — using published packages"
+fi
+
+# Build Flux
+NODE_OPTIONS='--max-old-space-size=4096' yarn build


### PR DESCRIPTION
## Automatic AD4M Branch Linking in CI

Enables coordinated development across `coasys/ad4m` and `coasys/flux` repos.

### How it works

When a Flux branch (e.g. `feat/my-feature`) is pushed, CI checks if `coasys/ad4m` has a branch with the same name via the GitHub API. If it does:

1. Clones the matching AD4M branch (shallow, single-branch)
2. Builds the TypeScript packages in order: `core` → `connect` → `hooks`
3. Yarn-links them into Flux before building

If no matching branch exists, Flux builds normally with published npm packages.

### What's included

- **`.github/workflows/build.yaml`** — GitHub Actions workflow with AD4M build caching (keyed by branch + source hash)
- **`scripts/build-with-ad4m-link.sh`** — Build script used by Netlify deploy previews (same logic)
- **`netlify.toml`** — Updated to use the build script

### Linked AD4M packages

| Package | AD4M source path |
|---------|-----------------|
| `@coasys/ad4m` | `core/` |
| `@coasys/ad4m-connect` | `connect/` |
| `@coasys/hooks-helpers` | `ad4m-hooks/helpers/` |
| `@coasys/ad4m-react-hooks` | `ad4m-hooks/react/` |
| `@coasys/ad4m-vue-hooks` | `ad4m-hooks/vue/` |

### Usage

Create a branch with the same name on both repos. Flux CI automatically picks up the AD4M changes without needing an npm publish.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a CI build workflow to run on dev and on pull requests, with caching to speed repeated builds.
  * Added orchestration to optionally link and reuse matching upstream packages to reduce rebuild time.
  * Updated deployment to use a custom build command and ensure consistent publish output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->