### PR TITLE
fix: pass model UUIDs for transcription billing instead of hardcoded strings

### DIFF
--- a/app/src/components/call/widgets/TranscriberWidget.vue
+++ b/app/src/components/call/widgets/TranscriberWidget.vue
@@ -476,7 +476,7 @@ async function startLocalTransciption(stream: MediaStream) {
   // Set up audio context & worklet node
   const moreDemaningParams = { startThreshold: 0.8 };
   streamId.value = await appStore.ad4mClient.ai.openTranscriptionStream(
-    'Whisper',
+    aiStore.whisperModelId,
     handleTranscriptionText,
     moreDemaningParams,
   );
@@ -490,7 +490,7 @@ async function startLocalTransciption(stream: MediaStream) {
   };
 
   fastStreamId.value = await appStore.ad4mClient.ai.openTranscriptionStream(
-    'whisper_tiny_quantized',
+    aiStore.tinyWhisperModelId,
     handleTranscriptionPreview,
     wordByWordParams,
   );

--- a/app/src/components/conversation/VoiceRecorder.vue
+++ b/app/src/components/conversation/VoiceRecorder.vue
@@ -47,7 +47,10 @@
 <script setup lang="ts">
 import { Ad4mClient } from '@coasys/ad4m';
 import { Message } from '@coasys/flux-api';
+import { useAiStore } from '@/stores';
 import { ref, onUnmounted } from 'vue';
+
+const aiStore = useAiStore();
 
 const props = defineProps<{
   client: Ad4mClient;
@@ -123,13 +126,13 @@ async function startRecording() {
     
     // Open transcription streams (final + preview)
     transcriptionStreamId = await props.client.ai.openTranscriptionStream(
-      'Whisper',
+      aiStore.whisperModelId,
       handleTranscriptionText,
       { startThreshold: 0.8 }
     );
     
     fastTranscriptionStreamId = await props.client.ai.openTranscriptionStream(
-      'whisper_tiny_quantized',
+      aiStore.tinyWhisperModelId,
       (text: string) => { previewText.value = text; },
       {
         startThreshold: 0.5,

--- a/app/src/stores/aiStore.ts
+++ b/app/src/stores/aiStore.ts
@@ -74,6 +74,20 @@ export const useAiStore = defineStore(
 
     const aiEnabled = computed(() => Boolean(defaultLLM.value && llmLoadingStatus.value?.status === 'Ready'));
 
+    const whisperModelId = computed(() => {
+      const model = allModels.value.find(
+        (m) => m.modelType === 'TRANSCRIPTION' && !m.local?.fileName?.includes('tiny'),
+      );
+      return model?.id ?? 'Whisper';
+    });
+
+    const tinyWhisperModelId = computed(() => {
+      const model = allModels.value.find(
+        (m) => m.modelType === 'TRANSCRIPTION' && m.local?.fileName?.includes('tiny'),
+      );
+      return model?.id ?? 'whisper_tiny_quantized';
+    });
+
     function setTranscriptionEnabled(payload: boolean): void {
       transcriptionEnabled.value = payload;
     }
@@ -364,6 +378,8 @@ export const useAiStore = defineStore(
       llmLoadingStatus,
       whisperLoadingStatus,
       whisperTinyLoadingStatus,
+      whisperModelId,
+      tinyWhisperModelId,
       transcriptionEnabled,
       transcriptionModel,
       transcriptionPreviewTimeout,


### PR DESCRIPTION
# PR: Fix transcription billing model IDs

**Branch:** `fix/transcription-billing-model-ids`  
**Base:** `dev`  
**Related:** ad4m PR #776 (`feature/transcription-billing`)

## Problem

Transcription billing was ignoring custom host rates set by hosts in the ad4m pricing table. When a host set a custom rate (e.g. $0.01/word) for "Whisper tiny quantized", the system still used the default rate.

### Root cause

The billing code in ad4m resolves rates via: `model UUID → db.get_model() → display name → host_rates lookup`.

Flux callers were passing hardcoded strings instead of model UUIDs:
- `'Whisper'` (display name) for the main transcription model
- `'whisper_tiny_quantized'` (file name) for the tiny model

Neither string is a UUID, so `db.get_model(id)` failed to find a match, and the billing code fell back to the default rate instead of using the host's custom rate.

## Solution

Query the model UUID from the already-loaded model list in the AI store rather than hardcoding strings.

### Changes

**`app/src/stores/aiStore.ts`**
- Added `whisperModelId` computed property — finds the non-tiny TRANSCRIPTION model and returns its UUID (falls back to `'Whisper'` if models haven't loaded)
- Added `tinyWhisperModelId` computed property — finds the tiny TRANSCRIPTION model and returns its UUID (falls back to `'whisper_tiny_quantized'`)
- Exported both in the store return

**`app/src/components/call/widgets/TranscriberWidget.vue`**
- Replaced hardcoded `'Whisper'` → `aiStore.whisperModelId`
- Replaced hardcoded `'whisper_tiny_quantized'` → `aiStore.tinyWhisperModelId`

**`app/src/components/conversation/VoiceRecorder.vue`**
- Added `useAiStore` import and store instance
- Replaced hardcoded `'Whisper'` → `aiStore.whisperModelId`
- Replaced hardcoded `'whisper_tiny_quantized'` → `aiStore.tinyWhisperModelId`

## How it works together with ad4m PR #776

The ad4m side (PR #776) fixes the backend billing lookup to resolve UUIDs to display names for rate matching. This Flux PR ensures callers actually pass UUIDs so that resolution works correctly. Both PRs are needed for end-to-end custom billing rates on transcription.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved transcription system flexibility by transitioning from static configurations to dynamic model selection, enhancing system adaptability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->