### PR TITLE
feat(app): navigate to home on credit depletion, return on Use App

### DIFF
--- a/app/src/app.ts
+++ b/app/src/app.ts
@@ -1,5 +1,5 @@
-import { useAppStore, useRouteMemoryStore } from '@/stores';
-import { getAd4mClient, isEmbedded } from '@coasys/ad4m-connect';
+import { useAppStore, useRouteMemoryStore, useWebrtcStore } from '@/stores';
+import { getAd4mConnect, isEmbedded } from '@coasys/ad4m-connect';
 import { createPinia, storeToRefs } from 'pinia';
 import { createPersistedState } from 'pinia-plugin-persistedstate';
 import { createApp, h } from 'vue';
@@ -38,6 +38,9 @@ const vueApp = createApp({ render: () => h(App) })
 const appStore = useAppStore(pinia);
 const routeMemoryStore = useRouteMemoryStore(pinia);
 
+// Tracks the route the user was on when credits ran out, so we can return them after topping up
+let savedPreCreditRoute: typeof routeMemoryStore.currentRoute | null = null;
+
 // Store the last saved route and current params before mounting the app
 const savedRoute = { ...routeMemoryStore.currentRoute };
 const currentParams = router.resolve(window.location.hash.slice(1) || '/').params;
@@ -49,7 +52,7 @@ vueApp.mount('#app');
 (async () => {
   try {
     // Initialize Ad4m client
-    const ad4mClient = await getAd4mClient({
+    const { client } = getAd4mConnect({
       appInfo: {
         name: 'Flux',
         description: 'A Social Toolkit for the New Internet',
@@ -58,7 +61,30 @@ vueApp.mount('#app');
       },
       capabilities: [{ with: { domain: '*', pointers: ['*'] }, can: ['*'] }],
       multiUser: true,
+      onCreditsDepleted: () => {
+        // Leave any active call first so the transcription widget is cleaned up
+        const webrtcStore = useWebrtcStore();
+        if (webrtcStore.inCall) webrtcStore.leaveRoom();
+
+        // Save current route once per depletion session, then retreat to the splash/home screen.
+        // The community views, signalling heartbeats, and AI task loops all stop naturally
+        // because nothing is mounted at /home.
+        if (!savedPreCreditRoute) {
+          savedPreCreditRoute = { ...routeMemoryStore.currentRoute };
+        }
+        routeMemoryStore.setCurrentRoute({});
+        router.push('/home');
+      },
+      onUseApp: () => {
+        // User explicitly clicked "Use App" after topping up — navigate back to where they were.
+        if (savedPreCreditRoute?.communityId) {
+          const lastRoute = routeMemoryStore.getLastCommunityRoute(savedPreCreditRoute.communityId as string);
+          router.push(lastRoute?.path || '/home');
+        }
+        savedPreCreditRoute = null;
+      },
     });
+    const ad4mClient = await client;
 
     if (!ad4mClient) throw new Error('Ad4mClient not available');
 

--- a/app/src/app.ts
+++ b/app/src/app.ts
@@ -63,7 +63,7 @@ vueApp.mount('#app');
       multiUser: true,
       onCreditsDepleted: () => {
         // Leave any active call first so the transcription widget is cleaned up
-        const webrtcStore = useWebrtcStore();
+        const webrtcStore = useWebrtcStore(pinia);
         if (webrtcStore.inCall) webrtcStore.leaveRoom();
 
         // Save current route once per depletion session, then retreat to the splash/home screen.


### PR DESCRIPTION
# Credits Depleted — Navigate to Home & Return on Use App

## Problem

When a user's hosting credits reached zero, the ad4m-connect modal appeared but the Flux app continued running behind it in a broken state:

- The agent remained present in channels/neighbourhoods, preventing AI tasks from being passed to other users with available credits
- AI processing tasks kept re-attempting and failing at the credit-gated step each time
- Signalling heartbeats continued advertising the agent's channel presence
- Any active WebRTC call (including its transcription widget) remained open

## Solution

Navigate to the `/home` splash screen when credits are depleted. Because no community content is mounted at `/home`, all the downstream problems resolve naturally — heartbeats stop broadcasting channel presence, AI task loops have no view to drive them, and the agent disappears from channel presence for other users.

When the user tops up and clicks **Use App**, they are returned to exactly where they were via `routeMemoryStore`.

## Changes

### `app/src/app.ts`

- Switched from `getAd4mClient` to `getAd4mConnect` (the advanced API that returns `{ core, client }`) to access the new lifecycle callbacks
- Added module-level `savedPreCreditRoute` to persist the user's pre-depletion location across the top-up flow
- **`onCreditsDepleted`**:
  1. Calls `webrtcStore.leaveRoom()` if currently in a call — signals peers, releases media, closes the transcription widget
  2. Saves `routeMemoryStore.currentRoute` to `savedPreCreditRoute` (guarded so repeat poll ticks don't overwrite it)
  3. Clears `currentRoute` in the store so the signalling heartbeat stops broadcasting channel presence
  4. Pushes to `/home`
- **`onUseApp`**:
  1. Looks up the last full community path from `routeMemoryStore.getLastCommunityRoute()` (which retains per-channel history even though `currentRoute` was cleared)
  2. Navigates back or falls back to `/home` if nothing is stored
  3. Clears `savedPreCreditRoute`

## Design Decisions

- **No auto-return on credits restored** — credits can be replenished by polling without any user action. Auto-returning would feel jarring and uncontrolled; "Use App" is the explicit, intentional gate
- **No call auto-rejoin** — `leaveRoom()` sends `WEBRTC_LEAVING_CALL` to all peers, so from their perspective the user left. Auto-rejoining minutes later would feel like a ghost reappearing. The call widget is naturally shown when navigating back to the channel, where the user can rejoin deliberately
- **`savedPreCreditRoute` is module-level** — survives the async lifecycle (it's only reset in `onUseApp`), and the `if (!savedPreCreditRoute)` guard means repeat `creditdepleted` events from the polling interval never overwrite the original saved location

## Dependency

Requires ad4m-connect version with the companion PR adding `onCreditsDepleted`, `onUseApp`, and `forceOpen`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credit-depletion handling: the app now gracefully navigates to home while preserving your current location, allowing seamless return to where you were after restoring credits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->