### PR TITLE
perf: replace FILTER NOT EXISTS + batch subgroup timestamp queries

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -113,3 +113,6 @@ jobs:
 
       - name: Build
         run: NODE_OPTIONS='--max-old-space-size=4096' pnpm build
+
+      - name: Test
+        run: pnpm test --filter @coasys/flux-api

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -93,3 +93,6 @@ jobs:
 
       - name: Build
         run: NODE_OPTIONS='--max-old-space-size=4096' pnpm build
+
+      - name: Test
+        run: pnpm test --filter @coasys/flux-api

--- a/app/package.json
+++ b/app/package.json
@@ -89,7 +89,7 @@
     "jest": "^29.7.0",
     "jest-transform-stub": "^2.0.0",
     "react": "^18.0.2",
-    "ts-jest": "^26.0.0",
+    "ts-jest": "^29",
     "typescript": "^5.0.4",
     "vite": "^4.3.5",
     "vite-plugin-babel-compiler": "^0.3.0",

--- a/app/src/components/conversation/timeline/TimelineColumn.vue
+++ b/app/src/components/conversation/timeline/TimelineColumn.vue
@@ -296,7 +296,25 @@ async function getUnprocessedItems() {
   return await channel.unprocessedItems();
 }
 
+// Predicates that indicate conversation metadata changes (require full refresh)
+const CONVERSATION_META_PREDICATES = ['flux://has_name', 'flux://has_summary', 'flux://has_child'];
+// Predicates that indicate new messages (only need unprocessed items refresh)
+const MESSAGE_PREDICATES = ['flux://has_expression', 'ad4m://has_child'];
+
+function isConversationMetaPredicate(predicate: string | undefined): boolean {
+  return !!predicate && CONVERSATION_META_PREDICATES.some(p => predicate.includes(p));
+}
+
+function isMessagePredicate(predicate: string | undefined): boolean {
+  // If predicate is unknown, treat as message (safe default — just refreshes unprocessed)
+  return !predicate || MESSAGE_PREDICATES.some(p => predicate.includes(p));
+}
+
 async function getData(firstRun?: boolean): Promise<void> {
+  return getDataFull(firstRun);
+}
+
+async function getDataFull(firstRun?: boolean): Promise<void> {
   if (gettingData.value) return;
 
   gettingData.value = true;
@@ -333,19 +351,70 @@ async function getData(firstRun?: boolean): Promise<void> {
   }
 }
 
-// TODO: Remove this if we can achieve the same with subscriptions. Currently indiscriminate about link types.
-function handleLinkAdded() {
+async function getDataIncremental(): Promise<void> {
+  if (gettingData.value) return;
+
+  gettingData.value = true;
+
+  try {
+    // Only refresh unprocessed items — conversations haven't changed
+    const newUnprocessedItems = await getUnprocessedItems();
+    unprocessedItems.value = newUnprocessedItems;
+    gettingData.value = false;
+
+    // Trigger a refresh in child components
+    refreshTrigger.value = refreshTrigger.value + 1;
+
+    // Check if we should process tasks
+    if (!aiEnabled.value) return;
+    const shouldProcess = await aiStore.checkIfWeShouldProcessTask(newUnprocessedItems, signallingService, channelUrl);
+    if (shouldProcess) {
+      const channel = new Channel(perspective, channelUrl);
+      aiStore.addTasksToProcessingQueue([{ communityId: perspective.sharedUrl!, channel }]);
+    }
+  } catch (error) {
+    console.error('Error fetching unprocessed items:', error);
+    gettingData.value = false;
+  }
+}
+
+async function refreshConversations(): Promise<void> {
+  try {
+    const newConversations = await getConversations();
+    if (conversations.value[0] && newConversations[0] && conversations.value[0].name !== newConversations[0].name) {
+      getPinnedConversations();
+      getRecentConversations();
+      getChannelsWithConversations();
+    }
+    conversations.value = newConversations;
+    refreshTrigger.value = refreshTrigger.value + 1;
+  } catch (error) {
+    console.error('Error refreshing conversations:', error);
+  }
+}
+
+// TODO: Remove this if we can achieve the same with subscriptions. Currently inspects link predicates.
+function handleLinkAdded(link?: any) {
+  const predicate = link?.data?.predicate;
+
+  // Determine which refresh path to take
+  const needsFullRefresh = isConversationMetaPredicate(predicate);
+  const refreshFn = needsFullRefresh ? getDataFull : getDataIncremental;
+
   // Debounced with LINK_ADDED_TIMEOUT to avoid concurrent data fetches
 
   // If in cooldown period, just mark that we've seen a new event and exit
+  // If any event during cooldown needs full refresh, upgrade the queued refresh
   if (linkAddedTimeout.value) {
     linkUpdatesQueued.value = true;
+    if (needsFullRefresh) (linkUpdatesQueued as any)._needsFull = true;
     return null;
   }
 
   // Otherwise get new data immediately
-  getData();
+  refreshFn();
   linkUpdatesQueued.value = false;
+  (linkUpdatesQueued as any)._needsFull = false;
 
   // Set cooldown period with callback that checks for queued updates
   linkAddedTimeout.value = setTimeout(() => {
@@ -353,8 +422,10 @@ function handleLinkAdded() {
 
     // If new events came in during cooldown, process them now
     if (linkUpdatesQueued.value) {
-      getData();
+      const fn = (linkUpdatesQueued as any)._needsFull ? getDataFull : getDataIncremental;
+      fn();
       linkUpdatesQueued.value = false;
+      (linkUpdatesQueued as any)._needsFull = false;
     }
   }, LINK_ADDED_TIMEOUT);
 

--- a/app/src/components/conversation/timeline/__tests__/timeline-link-handling.test.ts
+++ b/app/src/components/conversation/timeline/__tests__/timeline-link-handling.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Tests for getData() and handleLinkAdded() logic extracted from TimelineColumn.vue.
+ *
+ * These test the decision logic in isolation (predicate routing, debounce,
+ * concurrent fetch guard) without requiring the full Vue component.
+ */
+
+// ── Extracted logic under test ──
+
+const CONVERSATION_META_PREDICATES = ['flux://has_name', 'flux://has_summary', 'flux://has_child'];
+const MESSAGE_PREDICATES = ['flux://has_expression', 'ad4m://has_child'];
+
+function isConversationMetaPredicate(predicate: string | undefined): boolean {
+  return !!predicate && CONVERSATION_META_PREDICATES.some(p => predicate.includes(p));
+}
+
+function isMessagePredicate(predicate: string | undefined): boolean {
+  return !predicate || MESSAGE_PREDICATES.some(p => predicate.includes(p));
+}
+
+// Simulated state + handler
+function createHandler() {
+  const state = {
+    gettingData: false,
+    linkAddedTimeout: null as ReturnType<typeof setTimeout> | null,
+    linkUpdatesQueued: false,
+    _needsFull: false,
+    calls: [] as string[],
+  };
+
+  const getDataFull = () => { state.calls.push('full'); };
+  const getDataIncremental = () => { state.calls.push('incremental'); };
+
+  function handleLinkAdded(link?: any) {
+    const predicate = link?.data?.predicate;
+    const needsFullRefresh = isConversationMetaPredicate(predicate);
+
+    if (state.linkAddedTimeout) {
+      state.linkUpdatesQueued = true;
+      if (needsFullRefresh) state._needsFull = true;
+      return;
+    }
+
+    const refreshFn = needsFullRefresh ? getDataFull : getDataIncremental;
+    refreshFn();
+    state.linkUpdatesQueued = false;
+    state._needsFull = false;
+
+    state.linkAddedTimeout = setTimeout(() => {
+      state.linkAddedTimeout = null;
+      if (state.linkUpdatesQueued) {
+        const fn = state._needsFull ? getDataFull : getDataIncremental;
+        fn();
+        state.linkUpdatesQueued = false;
+        state._needsFull = false;
+      }
+    }, 100); // Short timeout for testing
+  }
+
+  function cleanup() {
+    if (state.linkAddedTimeout) {
+      clearTimeout(state.linkAddedTimeout);
+      state.linkAddedTimeout = null;
+    }
+  }
+
+  return { state, handleLinkAdded, cleanup };
+}
+
+// ── Tests ──
+
+describe('isConversationMetaPredicate', () => {
+  it('returns true for known meta predicates', () => {
+    expect(isConversationMetaPredicate('flux://has_name')).toBe(true);
+    expect(isConversationMetaPredicate('flux://has_summary')).toBe(true);
+  });
+
+  // Test #23: Unknown predicate
+  it('returns false for unknown predicates', () => {
+    expect(isConversationMetaPredicate('flux://unknown_thing')).toBe(false);
+    expect(isConversationMetaPredicate('ad4m://random')).toBe(false);
+  });
+
+  it('returns false for undefined/null predicates', () => {
+    expect(isConversationMetaPredicate(undefined)).toBe(false);
+  });
+});
+
+describe('isMessagePredicate', () => {
+  it('returns true for message predicates', () => {
+    expect(isMessagePredicate('flux://has_expression')).toBe(true);
+    expect(isMessagePredicate('ad4m://has_child')).toBe(true);
+  });
+
+  it('returns true for undefined (safe default)', () => {
+    expect(isMessagePredicate(undefined)).toBe(true);
+  });
+
+  it('returns false for non-message predicates', () => {
+    expect(isMessagePredicate('flux://has_name')).toBe(false);
+  });
+});
+
+describe('handleLinkAdded — link routing', () => {
+  // Test #23: Unknown predicate should trigger incremental (not full, not nothing)
+  it('unknown predicate triggers incremental refresh', () => {
+    const { state, handleLinkAdded, cleanup } = createHandler();
+    handleLinkAdded({ data: { predicate: 'flux://has_expression' } });
+    expect(state.calls).toEqual(['incremental']);
+    cleanup();
+  });
+
+  it('meta predicate triggers full refresh', () => {
+    const { state, handleLinkAdded, cleanup } = createHandler();
+    handleLinkAdded({ data: { predicate: 'flux://has_name' } });
+    expect(state.calls).toEqual(['full']);
+    cleanup();
+  });
+
+  // Test #24: Mixed predicates in quick succession escalate to full
+  it('message + meta predicate in quick succession escalates to full refresh', (done) => {
+    const { state, handleLinkAdded, cleanup } = createHandler();
+    // First: message predicate — triggers incremental immediately
+    handleLinkAdded({ data: { predicate: 'flux://has_expression' } });
+    expect(state.calls).toEqual(['incremental']);
+
+    // Second (during cooldown): meta predicate — queued, upgrades to full
+    handleLinkAdded({ data: { predicate: 'flux://has_name' } });
+    expect(state.linkUpdatesQueued).toBe(true);
+    expect(state._needsFull).toBe(true);
+
+    // After cooldown, the queued full refresh fires
+    setTimeout(() => {
+      expect(state.calls).toEqual(['incremental', 'full']);
+      cleanup();
+      done();
+    }, 150);
+  });
+
+  // Test #25: gettingData guard prevents concurrent fetches
+  it('gettingData guard prevents concurrent getData calls', () => {
+    // This tests the pattern: if (gettingData) return;
+    let callCount = 0;
+    let gettingData = false;
+
+    async function getData() {
+      if (gettingData) return;
+      gettingData = true;
+      callCount++;
+      // Simulate async work
+      await new Promise(r => setTimeout(r, 50));
+      gettingData = false;
+    }
+
+    // Fire two concurrent calls
+    getData();
+    getData(); // Should be blocked by guard
+    expect(callCount).toBe(1);
+  });
+});
+
+describe('handleLinkAdded — debounce behavior', () => {
+  it('queues events during cooldown period', () => {
+    const { state, handleLinkAdded, cleanup } = createHandler();
+    // First event fires immediately
+    handleLinkAdded({ data: { predicate: 'flux://has_expression' } });
+    expect(state.calls).toEqual(['incremental']);
+
+    // Second event during cooldown is queued, not fired
+    handleLinkAdded({ data: { predicate: 'flux://has_expression' } });
+    expect(state.calls).toEqual(['incremental']); // Still only 1 call
+    expect(state.linkUpdatesQueued).toBe(true);
+
+    cleanup();
+  });
+
+  it('processes queued events after cooldown expires', (done) => {
+    const { state, handleLinkAdded } = createHandler();
+    handleLinkAdded({ data: { predicate: 'flux://has_expression' } });
+    handleLinkAdded({ data: { predicate: 'flux://has_expression' } });
+
+    setTimeout(() => {
+      // After cooldown, queued incremental should have fired
+      expect(state.calls).toEqual(['incremental', 'incremental']);
+      done();
+    }, 150);
+  });
+});

--- a/packages/api/jest.config.cjs
+++ b/packages/api/jest.config.cjs
@@ -1,0 +1,8 @@
+module.exports = {
+  preset: 'ts-jest',
+  rootDir: 'src',
+  testTimeout: 30000,
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest',
+  },
+};

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -6,7 +6,7 @@
   "license": "ISC",
   "type": "module",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest --config jest.config.cjs --forceExit"
   },
   "main": "./src/index.ts",
   "module": "./src/index.ts",
@@ -20,6 +20,11 @@
     "@coasys/flux-types": "workspace:*",
     "@coasys/flux-utils": "workspace:*",
     "uuid": "^9.0.0"
+  },
+  "devDependencies": {
+    "@types/jest": "^29",
+    "jest": "^29",
+    "ts-jest": "^29"
   },
   "peerDependencies": {
     "@coasys/ad4m": "0.11.1"

--- a/packages/api/src/channel/channel-query.test.ts
+++ b/packages/api/src/channel/channel-query.test.ts
@@ -1,13 +1,11 @@
 /**
- * Tests for the SPARQL query fixes in channel/index.ts.
+ * Tests for the SPARQL queries in Channel.unprocessedItems().
  *
  * Validates that:
  * 1. The processedQuery does NOT scope subgroups as direct children of the channel
  *    (bug: subgroups are grandchildren via conversations, so channel→subgroup never matched)
  * 2. The processedQuery finds items globally via any conversation_subgroup
  * 3. The final VALUES query re-verifies channel membership
- *
- * Run: npx tsx packages/api/src/channel/channel-query.test.ts
  */
 
 const SUBGROUP_ITEM = 'flux://has_item';
@@ -39,7 +37,7 @@ function buildProcessedQuery(channelId: string): string {
 }
 
 function buildDataQuery(channelId: string, unprocessedIds: string[]): string {
-  const valuesClause = unprocessedIds.map(id => `<${id}>`).join(' ');
+  const valuesClause = unprocessedIds.map((id) => `<${id}>`).join(' ');
   return `
     SELECT ?id ?author ?timestamp ?type ?body ?title ?taskName WHERE {
       VALUES ?id { ${valuesClause} }
@@ -56,70 +54,55 @@ function buildDataQuery(channelId: string, unprocessedIds: string[]): string {
   `;
 }
 
-// --- Test runner ---
-let passed = 0;
-let failed = 0;
-
-function assert(condition: boolean, msg: string) {
-  if (condition) {
-    passed++;
-    console.log(`  ✓ ${msg}`);
-  } else {
-    failed++;
-    console.error(`  ✗ ${msg}`);
-  }
-}
-
-// --- Tests ---
-
-console.log('BUG: old processedQuery wrongly scoped subgroups as channel children');
-{
+describe('processedQuery — regression: subgroups are not direct children of channels', () => {
   const channelId = 'flux://channel/abc123';
-  const q = buildProcessedQuery_BROKEN(channelId);
-  // This pattern is the bug — it assumes channel → has_child → subgroup
-  assert(
-    q.includes(`<${channelId}> <ad4m://has_child> ?sg`),
-    'broken query links channel directly to subgroup (the bug)'
-  );
-}
 
-console.log('\nFIX: processedQuery finds items via any subgroup globally');
-{
-  const channelId = 'flux://channel/abc123';
-  const q = buildProcessedQuery(channelId);
-  // Must NOT contain the channel→subgroup direct link
-  assert(
-    !q.includes(`<${channelId}>`),
-    'fixed query does NOT reference channel ID (global scan)'
-  );
-  assert(
-    !q.includes('<ad4m://has_child>'),
-    'fixed query does NOT use has_child (no channel scoping)'
-  );
-  // Must still find items via subgroups
-  assert(
-    q.includes(`<${SUBGROUP_ITEM}>`),
-    'fixed query includes SUBGROUP_ITEM predicate'
-  );
-  assert(
-    q.includes('<flux://entry_type> <flux://conversation_subgroup>'),
-    'fixed query filters for conversation_subgroup type'
-  );
-}
+  it('old (broken) query wrongly links channel directly to subgroup', () => {
+    const q = buildProcessedQuery_BROKEN(channelId);
+    // This pattern is the bug — it assumes channel → has_child → subgroup
+    // which never matches because the real structure is channel → conversation → subgroup
+    expect(q).toContain(`<${channelId}> <ad4m://has_child> ?sg`);
+  });
 
-console.log('\nfinal VALUES query re-verifies channel membership');
-{
+  it('fixed query does NOT reference channel ID (global scan)', () => {
+    const q = buildProcessedQuery(channelId);
+    expect(q).not.toContain(`<${channelId}>`);
+  });
+
+  it('fixed query does NOT use has_child (no channel scoping)', () => {
+    const q = buildProcessedQuery(channelId);
+    expect(q).not.toContain('<ad4m://has_child>');
+  });
+
+  it('fixed query includes SUBGROUP_ITEM predicate', () => {
+    const q = buildProcessedQuery(channelId);
+    expect(q).toContain(`<${SUBGROUP_ITEM}>`);
+  });
+
+  it('fixed query filters for conversation_subgroup type', () => {
+    const q = buildProcessedQuery(channelId);
+    expect(q).toContain('<flux://entry_type> <flux://conversation_subgroup>');
+  });
+});
+
+describe('dataQuery — VALUES clause and channel membership', () => {
   const channelId = 'flux://channel/abc123';
   const ids = ['flux://item/1', 'flux://item/2'];
-  const q = buildDataQuery(channelId, ids);
-  assert(q.includes('VALUES ?id'), 'dataQuery uses VALUES clause');
-  assert(q.includes(channelId), 'dataQuery includes channel ID');
-  assert(
-    q.includes(`<${channelId}> <ad4m://has_child> ?id`),
-    'dataQuery re-verifies channel membership via has_child join'
-  );
-  assert(!q.includes('FILTER NOT EXISTS'), 'dataQuery avoids O(N²) FILTER NOT EXISTS');
-}
 
-console.log(`\n${passed} passed, ${failed} failed`);
-process.exit(failed > 0 ? 1 : 0);
+  it('uses VALUES clause for unprocessed IDs', () => {
+    const q = buildDataQuery(channelId, ids);
+    expect(q).toContain('VALUES ?id');
+    expect(q).toContain('<flux://item/1>');
+    expect(q).toContain('<flux://item/2>');
+  });
+
+  it('re-verifies channel membership via has_child join', () => {
+    const q = buildDataQuery(channelId, ids);
+    expect(q).toContain(`<${channelId}> <ad4m://has_child> ?id`);
+  });
+
+  it('avoids O(N²) FILTER NOT EXISTS', () => {
+    const q = buildDataQuery(channelId, ids);
+    expect(q).not.toContain('FILTER NOT EXISTS');
+  });
+});

--- a/packages/api/src/channel/channel-query.test.ts
+++ b/packages/api/src/channel/channel-query.test.ts
@@ -85,6 +85,100 @@ describe('processedQuery — regression: subgroups are not direct children of ch
   });
 });
 
+describe('set-difference logic — unprocessedItems regression', () => {
+  // Mirror the JS set-difference logic from Channel.unprocessedItems()
+  function computeUnprocessed(allItems: string[], processedItems: string[]): string[] {
+    const processedSet = new Set(processedItems);
+    return allItems.filter(id => !processedSet.has(id));
+  }
+
+  it('returns items not in processedSet', () => {
+    const all = ['item1', 'item2', 'item3', 'item4'];
+    const processed = ['item1', 'item3'];
+    expect(computeUnprocessed(all, processed)).toEqual(['item2', 'item4']);
+  });
+
+  it('returns ALL items when processedSet is empty (the original bug scenario)', () => {
+    // This was the bug: processedQuery returned nothing (wrong scoping),
+    // so processedSet was empty, making ALL items "unprocessed" every time.
+    const all = ['item1', 'item2', 'item3'];
+    expect(computeUnprocessed(all, [])).toEqual(['item1', 'item2', 'item3']);
+  });
+
+  it('returns empty array when all items are processed', () => {
+    const all = ['item1', 'item2'];
+    expect(computeUnprocessed(all, ['item1', 'item2'])).toEqual([]);
+  });
+
+  it('handles duplicates in allItems gracefully', () => {
+    const all = ['item1', 'item2', 'item1', 'item3'];
+    const processed = ['item1'];
+    // Duplicates in allItems pass through — both instances of item1 are filtered
+    expect(computeUnprocessed(all, processed)).toEqual(['item2', 'item3']);
+  });
+
+  it('handles duplicates in processedItems gracefully', () => {
+    const all = ['item1', 'item2', 'item3'];
+    const processed = ['item1', 'item1', 'item3'];
+    expect(computeUnprocessed(all, processed)).toEqual(['item2']);
+  });
+});
+
+describe('processedQuery — grandchild relationship documentation', () => {
+  const channelId = 'flux://channel/abc123';
+
+  // The link structure is: channel → conversation → subgroup → item.
+  // The processedQuery must search for items via ANY subgroup globally,
+  // not assume subgroups are direct children of the channel.
+  it('fixed query searches globally, not scoped to channel', () => {
+    const q = buildProcessedQuery(channelId);
+    // Must NOT contain any reference to the channel ID
+    expect(q).not.toContain(channelId);
+    // Must NOT try to traverse channel→subgroup directly
+    expect(q).not.toContain('<ad4m://has_child>');
+    // Must find items via subgroup→item globally
+    expect(q).toContain(`<${SUBGROUP_ITEM}>`);
+  });
+});
+
+describe('Conversation.subgroupsData batchTimestampQuery pattern', () => {
+  // Mirror the query built in Conversation.subgroupsData()
+  function buildBatchTimestampQuery(subgroupIds: string[]): string {
+    const valuesClause = subgroupIds.map(id => `<${id}>`).join(' ');
+    return `
+      SELECT ?sg ?transcriptStart ?channelTs WHERE {
+        VALUES ?sg { ${valuesClause} }
+        GRAPH ?g1 { ?sg <${SUBGROUP_ITEM}> ?item . }
+        GRAPH ?chLink { ?chSrc <ad4m://has_child> ?item . }
+        ?chLink <ad4m://ontology/timestamp> ?channelTs .
+        GRAPH ?g2 { ?chSrc <flux://entry_type> <flux://has_channel> . }
+        OPTIONAL { GRAPH ?g3 { ?item <flux://transcript_started_at> ?transcriptStart . } }
+      }
+    `;
+  }
+
+  it('uses VALUES clause with subgroup IDs', () => {
+    const q = buildBatchTimestampQuery(['sg1', 'sg2']);
+    expect(q).toContain('VALUES ?sg { <sg1> <sg2> }');
+  });
+
+  it('joins via SUBGROUP_ITEM (flux://has_item)', () => {
+    const q = buildBatchTimestampQuery(['sg1']);
+    expect(q).toContain(`<${SUBGROUP_ITEM}>`);
+  });
+
+  it('gets timestamps from channel→item links', () => {
+    const q = buildBatchTimestampQuery(['sg1']);
+    expect(q).toContain('<ad4m://ontology/timestamp> ?channelTs');
+    expect(q).toContain('<ad4m://has_child> ?item');
+  });
+
+  it('generates empty VALUES for no subgroups', () => {
+    const q = buildBatchTimestampQuery([]);
+    expect(q).toContain('VALUES ?sg {  }');
+  });
+});
+
 describe('dataQuery — VALUES clause and channel membership', () => {
   const channelId = 'flux://channel/abc123';
   const ids = ['flux://item/1', 'flux://item/2'];

--- a/packages/api/src/channel/channel-query.test.ts
+++ b/packages/api/src/channel/channel-query.test.ts
@@ -1,31 +1,38 @@
 /**
  * Tests for the SPARQL query fixes in channel/index.ts.
  *
- * These validate that:
- * 1. The processedQuery is scoped to the channel (includes channel ID in the query)
- * 2. The final VALUES query re-verifies channel membership (includes channel join)
+ * Validates that:
+ * 1. The processedQuery does NOT scope subgroups as direct children of the channel
+ *    (bug: subgroups are grandchildren via conversations, so channel→subgroup never matched)
+ * 2. The processedQuery finds items globally via any conversation_subgroup
+ * 3. The final VALUES query re-verifies channel membership
  *
  * Run: npx tsx packages/api/src/channel/channel-query.test.ts
  */
 
-// Replicate the query construction logic from Channel.unprocessedItems()
-// to validate SPARQL correctness without needing a full AD4M runtime.
+const SUBGROUP_ITEM = 'flux://has_item';
 
-function buildAllItemsQuery(channelId: string): string {
+// --- Query builders (mirror the logic in Channel.unprocessedItems()) ---
+
+function buildProcessedQuery_BROKEN(channelId: string): string {
+  // OLD (buggy): assumes subgroups are direct children of the channel
   return `
     SELECT ?id WHERE {
-      GRAPH ?g1 { <${channelId}> <ad4m://has_child> ?id . }
-      GRAPH ?g2 { ?id <flux://entry_type> ?type . }
-      FILTER(?type IN (<flux://has_message>, <flux://has_post>, <flux://has_task>))
+      GRAPH ?g0 { <${channelId}> <ad4m://has_child> ?sg . }
+      GRAPH ?g1 { ?sg <${SUBGROUP_ITEM}> ?id . }
+      GRAPH ?g2 { ?sg <flux://entry_type> <flux://conversation_subgroup> . }
     }
   `;
 }
 
 function buildProcessedQuery(channelId: string): string {
+  // FIXED: find items in ANY conversation_subgroup globally.
+  // Subgroups are grandchildren of channels (channel → conversation → subgroup),
+  // so scoping through channel never matched. Items are unique to channels anyway.
+  void channelId; // not used — intentionally global
   return `
     SELECT ?id WHERE {
-      GRAPH ?g0 { <${channelId}> <ad4m://has_child> ?sg . }
-      GRAPH ?g1 { ?sg <${'flux://has_subgroup_item'}> ?id . }
+      GRAPH ?g1 { ?sg <${SUBGROUP_ITEM}> ?id . }
       GRAPH ?g2 { ?sg <flux://entry_type> <flux://conversation_subgroup> . }
     }
   `;
@@ -49,7 +56,7 @@ function buildDataQuery(channelId: string, unprocessedIds: string[]): string {
   `;
 }
 
-// --- Tests ---
+// --- Test runner ---
 let passed = 0;
 let failed = 0;
 
@@ -63,15 +70,41 @@ function assert(condition: boolean, msg: string) {
   }
 }
 
-console.log('processedQuery scoped to channel');
+// --- Tests ---
+
+console.log('BUG: old processedQuery wrongly scoped subgroups as channel children');
+{
+  const channelId = 'flux://channel/abc123';
+  const q = buildProcessedQuery_BROKEN(channelId);
+  // This pattern is the bug — it assumes channel → has_child → subgroup
+  assert(
+    q.includes(`<${channelId}> <ad4m://has_child> ?sg`),
+    'broken query links channel directly to subgroup (the bug)'
+  );
+}
+
+console.log('\nFIX: processedQuery finds items via any subgroup globally');
 {
   const channelId = 'flux://channel/abc123';
   const q = buildProcessedQuery(channelId);
-  assert(q.includes(channelId), 'processedQuery includes channel ID');
-  assert(q.includes('<ad4m://has_child>'), 'processedQuery joins via has_child from channel');
-  assert(!q.includes('SELECT ?id WHERE {\n      GRAPH ?g1 { ?sg'), 'processedQuery is not a global scan — scoped via channel→subgroup');
-  // Verify it starts from the channel, not from all subgroups globally
-  assert(q.includes(`<${channelId}> <ad4m://has_child> ?sg`), 'processedQuery starts traversal from channel ID');
+  // Must NOT contain the channel→subgroup direct link
+  assert(
+    !q.includes(`<${channelId}>`),
+    'fixed query does NOT reference channel ID (global scan)'
+  );
+  assert(
+    !q.includes('<ad4m://has_child>'),
+    'fixed query does NOT use has_child (no channel scoping)'
+  );
+  // Must still find items via subgroups
+  assert(
+    q.includes(`<${SUBGROUP_ITEM}>`),
+    'fixed query includes SUBGROUP_ITEM predicate'
+  );
+  assert(
+    q.includes('<flux://entry_type> <flux://conversation_subgroup>'),
+    'fixed query filters for conversation_subgroup type'
+  );
 }
 
 console.log('\nfinal VALUES query re-verifies channel membership');
@@ -81,9 +114,10 @@ console.log('\nfinal VALUES query re-verifies channel membership');
   const q = buildDataQuery(channelId, ids);
   assert(q.includes('VALUES ?id'), 'dataQuery uses VALUES clause');
   assert(q.includes(channelId), 'dataQuery includes channel ID');
-  assert(q.includes(`<${channelId}> <ad4m://has_child> ?id`), 'dataQuery re-verifies channel membership via has_child join');
-  // This is the key fix: the final query doesn't just trust the item IDs,
-  // it re-joins with the channel to confirm membership (race condition mitigation)
+  assert(
+    q.includes(`<${channelId}> <ad4m://has_child> ?id`),
+    'dataQuery re-verifies channel membership via has_child join'
+  );
   assert(!q.includes('FILTER NOT EXISTS'), 'dataQuery avoids O(N²) FILTER NOT EXISTS');
 }
 

--- a/packages/api/src/channel/channel-query.test.ts
+++ b/packages/api/src/channel/channel-query.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests for the SPARQL query fixes in channel/index.ts.
+ *
+ * These validate that:
+ * 1. The processedQuery is scoped to the channel (includes channel ID in the query)
+ * 2. The final VALUES query re-verifies channel membership (includes channel join)
+ *
+ * Run: npx tsx packages/api/src/channel/channel-query.test.ts
+ */
+
+// Replicate the query construction logic from Channel.unprocessedItems()
+// to validate SPARQL correctness without needing a full AD4M runtime.
+
+function buildAllItemsQuery(channelId: string): string {
+  return `
+    SELECT ?id WHERE {
+      GRAPH ?g1 { <${channelId}> <ad4m://has_child> ?id . }
+      GRAPH ?g2 { ?id <flux://entry_type> ?type . }
+      FILTER(?type IN (<flux://has_message>, <flux://has_post>, <flux://has_task>))
+    }
+  `;
+}
+
+function buildProcessedQuery(channelId: string): string {
+  return `
+    SELECT ?id WHERE {
+      GRAPH ?g0 { <${channelId}> <ad4m://has_child> ?sg . }
+      GRAPH ?g1 { ?sg <${'flux://has_subgroup_item'}> ?id . }
+      GRAPH ?g2 { ?sg <flux://entry_type> <flux://conversation_subgroup> . }
+    }
+  `;
+}
+
+function buildDataQuery(channelId: string, unprocessedIds: string[]): string {
+  const valuesClause = unprocessedIds.map(id => `<${id}>`).join(' ');
+  return `
+    SELECT ?id ?author ?timestamp ?type ?body ?title ?taskName WHERE {
+      VALUES ?id { ${valuesClause} }
+      GRAPH ?link1 { <${channelId}> <ad4m://has_child> ?id . }
+      ?link1 <ad4m://ontology/author> ?author .
+      ?link1 <ad4m://ontology/timestamp> ?timestamp .
+      GRAPH ?g2 { ?id <flux://entry_type> ?type . }
+      FILTER(?type IN (<flux://has_message>, <flux://has_post>, <flux://has_task>))
+      OPTIONAL { GRAPH ?g4 { ?id <flux://body> ?body . } }
+      OPTIONAL { GRAPH ?g5 { ?id <flux://title> ?title . } }
+      OPTIONAL { GRAPH ?g6 { ?id <flux://name> ?taskName . } }
+    }
+    ORDER BY ?timestamp
+  `;
+}
+
+// --- Tests ---
+let passed = 0;
+let failed = 0;
+
+function assert(condition: boolean, msg: string) {
+  if (condition) {
+    passed++;
+    console.log(`  ✓ ${msg}`);
+  } else {
+    failed++;
+    console.error(`  ✗ ${msg}`);
+  }
+}
+
+console.log('processedQuery scoped to channel');
+{
+  const channelId = 'flux://channel/abc123';
+  const q = buildProcessedQuery(channelId);
+  assert(q.includes(channelId), 'processedQuery includes channel ID');
+  assert(q.includes('<ad4m://has_child>'), 'processedQuery joins via has_child from channel');
+  assert(!q.includes('SELECT ?id WHERE {\n      GRAPH ?g1 { ?sg'), 'processedQuery is not a global scan — scoped via channel→subgroup');
+  // Verify it starts from the channel, not from all subgroups globally
+  assert(q.includes(`<${channelId}> <ad4m://has_child> ?sg`), 'processedQuery starts traversal from channel ID');
+}
+
+console.log('\nfinal VALUES query re-verifies channel membership');
+{
+  const channelId = 'flux://channel/abc123';
+  const ids = ['flux://item/1', 'flux://item/2'];
+  const q = buildDataQuery(channelId, ids);
+  assert(q.includes('VALUES ?id'), 'dataQuery uses VALUES clause');
+  assert(q.includes(channelId), 'dataQuery includes channel ID');
+  assert(q.includes(`<${channelId}> <ad4m://has_child> ?id`), 'dataQuery re-verifies channel membership via has_child join');
+  // This is the key fix: the final query doesn't just trust the item IDs,
+  // it re-joins with the channel to confirm membership (race condition mitigation)
+  assert(!q.includes('FILTER NOT EXISTS'), 'dataQuery avoids O(N²) FILTER NOT EXISTS');
+}
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/packages/api/src/channel/index.ts
+++ b/packages/api/src/channel/index.ts
@@ -137,10 +137,16 @@ export class Channel extends Ad4mModel {
         }
       `;
 
-      // Query 2: Get processed item IDs scoped to THIS channel's subgroups only
+      // Query 2: Get all item IDs that have been placed into ANY conversation subgroup.
+      // NOTE: We do NOT scope this through the channel because subgroups are
+      // *grandchildren* of channels (channel → conversation → subgroup), not
+      // direct children.  The previous channel-scoped query assumed
+      //   channel --has_child--> subgroup
+      // which never matched, so processedSet was always empty and every item
+      // appeared unprocessed on every poll.  Scoping globally is correct
+      // because items are unique to channels anyway.
       const processedQuery = `
         SELECT ?id WHERE {
-          GRAPH ?g0 { <${this.id}> <ad4m://has_child> ?sg . }
           GRAPH ?g1 { ?sg <${SUBGROUP_ITEM}> ?id . }
           GRAPH ?g2 { ?sg <flux://entry_type> <flux://conversation_subgroup> . }
         }

--- a/packages/api/src/channel/index.ts
+++ b/packages/api/src/channel/index.ts
@@ -137,14 +137,18 @@ export class Channel extends Ad4mModel {
         }
       `;
 
-      // Query 2: Get all processed item IDs (items already in a subgroup)
+      // Query 2: Get processed item IDs scoped to THIS channel's subgroups only
       const processedQuery = `
         SELECT ?id WHERE {
+          GRAPH ?g0 { <${this.id}> <ad4m://has_child> ?sg . }
           GRAPH ?g1 { ?sg <${SUBGROUP_ITEM}> ?id . }
           GRAPH ?g2 { ?sg <flux://entry_type> <flux://conversation_subgroup> . }
         }
       `;
 
+      // NOTE: Race window — links added between these two queries could cause
+      // an item to appear in allItems but not processedSet (or vice-versa).
+      // The final VALUES query re-verifies channel membership to mitigate this.
       const [allItemsResult, processedResult] = await Promise.all([
         this.perspective.querySparql(allItemsQuery),
         this.perspective.querySparql(processedQuery),

--- a/packages/api/src/channel/index.ts
+++ b/packages/api/src/channel/index.ts
@@ -1,14 +1,5 @@
 import { Ad4mModel, HasMany, HasManyMethods, Flag, Literal, Model, Property } from '@coasys/ad4m';
-
-// SPARQL migration helper
-function parseLit(val: string | undefined): string {
-  if (!val) return '';
-  try {
-    const result = Literal.fromUrl(val).get();
-    if (result && typeof result === 'object') return result.data ?? JSON.stringify(result);
-    return result;
-  } catch { return val; }
-}
+import { parseLit } from '../utils/parseLit';
 import { community } from '@coasys/flux-constants';
 import { EntryType } from '@coasys/flux-types';
 import { SynergyGroup, SynergyItem, icons } from '@coasys/flux-utils';

--- a/packages/api/src/channel/index.ts
+++ b/packages/api/src/channel/index.ts
@@ -125,20 +125,48 @@ export class Channel extends Ad4mModel {
   }
 
   async unprocessedItems(): Promise<SynergyItem[]> {
-    // Get all unprocessed items in the channel
+    // Get all unprocessed items in the channel using set-difference approach
+    // instead of FILTER NOT EXISTS (which is O(N²) in Oxigraph)
     try {
-      // SPARQL migration
-      const sparqlQuery = `
+      // Query 1: Get all item IDs in channel
+      const allItemsQuery = `
+        SELECT ?id WHERE {
+          GRAPH ?g1 { <${this.id}> <ad4m://has_child> ?id . }
+          GRAPH ?g2 { ?id <flux://entry_type> ?type . }
+          FILTER(?type IN (<flux://has_message>, <flux://has_post>, <flux://has_task>))
+        }
+      `;
+
+      // Query 2: Get all processed item IDs (items already in a subgroup)
+      const processedQuery = `
+        SELECT ?id WHERE {
+          GRAPH ?g1 { ?sg <${SUBGROUP_ITEM}> ?id . }
+          GRAPH ?g2 { ?sg <flux://entry_type> <flux://conversation_subgroup> . }
+        }
+      `;
+
+      const [allItemsResult, processedResult] = await Promise.all([
+        this.perspective.querySparql(allItemsQuery),
+        this.perspective.querySparql(processedQuery),
+      ]);
+
+      const processedSet = new Set((processedResult || []).map((r: any) => r.id));
+      const unprocessedIds = (allItemsResult || [])
+        .map((r: any) => r.id)
+        .filter((id: string) => id && !processedSet.has(id));
+
+      if (unprocessedIds.length === 0) return [];
+
+      // Query 3: Get full data only for unprocessed items using VALUES clause
+      const valuesClause = unprocessedIds.map((id: string) => `<${id}>`).join(' ');
+      const dataQuery = `
         SELECT ?id ?author ?timestamp ?type ?body ?title ?taskName WHERE {
+          VALUES ?id { ${valuesClause} }
           GRAPH ?link1 { <${this.id}> <ad4m://has_child> ?id . }
           ?link1 <ad4m://ontology/author> ?author .
           ?link1 <ad4m://ontology/timestamp> ?timestamp .
           GRAPH ?g2 { ?id <flux://entry_type> ?type . }
           FILTER(?type IN (<flux://has_message>, <flux://has_post>, <flux://has_task>))
-          FILTER NOT EXISTS {
-            GRAPH ?sgLink { ?sg <${SUBGROUP_ITEM}> ?id . }
-            GRAPH ?g3 { ?sg <flux://entry_type> <flux://conversation_subgroup> . }
-          }
           OPTIONAL { GRAPH ?g4 { ?id <flux://body> ?body . } }
           OPTIONAL { GRAPH ?g5 { ?id <flux://title> ?title . } }
           OPTIONAL { GRAPH ?g6 { ?id <flux://name> ?taskName . } }
@@ -146,7 +174,7 @@ export class Channel extends Ad4mModel {
         ORDER BY ?timestamp
       `;
 
-      const sparqlResult = await this.perspective.querySparql(sparqlQuery);
+      const sparqlResult = await this.perspective.querySparql(dataQuery);
 
       // Deduplicate by id
       const itemMap = new Map<string, any>();

--- a/packages/api/src/conversation-subgroup/index.ts
+++ b/packages/api/src/conversation-subgroup/index.ts
@@ -1,14 +1,5 @@
 import { Model, Ad4mModel, Flag, HasMany, Property, Literal } from '@coasys/ad4m';
-
-// SPARQL migration helper
-function parseLit(val: string | undefined): string {
-  if (!val) return '';
-  try {
-    const result = Literal.fromUrl(val).get();
-    if (result && typeof result === 'object') return result.data ?? JSON.stringify(result);
-    return result;
-  } catch { return val; }
-}
+import { parseLit } from '../utils/parseLit';
 import Topic, { TopicWithRelevance } from '../topic';
 import SemanticRelationship from '../semantic-relationship';
 import { SynergyTopic, SynergyItem, icons } from '@coasys/flux-utils';

--- a/packages/api/src/conversation/index.ts
+++ b/packages/api/src/conversation/index.ts
@@ -1,14 +1,6 @@
 import { Ad4mModel, Ad4mClient, Flag, HasMany, HasManyMethods, Link, Literal, Model, Property } from '@coasys/ad4m';
 
-// SPARQL migration helper
-function parseLit(val: string | undefined): string {
-  if (!val) return '';
-  try {
-    const result = Literal.fromUrl(val).get();
-    if (result && typeof result === 'object') return result.data ?? JSON.stringify(result);
-    return result;
-  } catch { return val; }
-}
+import { parseLit } from '../utils/parseLit';
 import { getProfile, Topic } from '@coasys/flux-api';
 import { ProcessingState, Profile } from '@coasys/flux-types';
 import { SynergyGroup, SynergyItem, SynergyTopic } from '@coasys/flux-utils';
@@ -153,7 +145,7 @@ export class Conversation extends Ad4mModel {
       const batchTimestampQuery = `
         SELECT ?sg ?transcriptStart ?channelTs WHERE {
           VALUES ?sg { ${valuesClause} }
-          GRAPH ?g1 { ?sg <flux://has_item> ?item . }
+          GRAPH ?g1 { ?sg <${SUBGROUP_ITEM}> ?item . }
           GRAPH ?chLink { ?chSrc <ad4m://has_child> ?item . }
           ?chLink <ad4m://ontology/timestamp> ?channelTs .
           GRAPH ?g2 { ?chSrc <flux://entry_type> <flux://has_channel> . }

--- a/packages/api/src/conversation/index.ts
+++ b/packages/api/src/conversation/index.ts
@@ -144,46 +144,52 @@ export class Conversation extends Ad4mModel {
         }
       }
 
-      // Get timestamps for each subgroup separately
-      const subgroups = await Promise.all(
-        Array.from(subgroupMap.values()).map(async (subgroup: any) => {
-          // SPARQL migration - get creation timestamps from channel→item links, not grouping timestamps from subgroup→item links
-          const timestampQuery = `
-            SELECT ?transcriptStart ?channelTs WHERE {
-              GRAPH ?g1 { <${subgroup.id}> <flux://has_item> ?item . }
-              GRAPH ?chLink { ?chSrc <ad4m://has_child> ?item . }
-              ?chLink <ad4m://ontology/timestamp> ?channelTs .
-              GRAPH ?g2 { ?chSrc <flux://entry_type> <flux://has_channel> . }
-              OPTIONAL { GRAPH ?g3 { ?item <flux://transcript_started_at> ?transcriptStart . } }
-            }
-            ORDER BY ?channelTs
-          `;
+      const subgroupIds = Array.from(subgroupMap.keys());
+      if (subgroupIds.length === 0) return [];
 
-          const timestampResults = await this.perspective.querySparql(timestampQuery);
+      // Batch query: get timestamps for ALL subgroups in a single query
+      // instead of one query per subgroup (N+1 → 1)
+      const valuesClause = subgroupIds.map(id => `<${id}>`).join(' ');
+      const batchTimestampQuery = `
+        SELECT ?sg ?transcriptStart ?channelTs WHERE {
+          VALUES ?sg { ${valuesClause} }
+          GRAPH ?g1 { ?sg <flux://has_item> ?item . }
+          GRAPH ?chLink { ?chSrc <ad4m://has_child> ?item . }
+          ?chLink <ad4m://ontology/timestamp> ?channelTs .
+          GRAPH ?g2 { ?chSrc <flux://entry_type> <flux://has_channel> . }
+          OPTIONAL { GRAPH ?g3 { ?item <flux://transcript_started_at> ?transcriptStart . } }
+        }
+      `;
 
-          // Filter out null/undefined timestamps and convert to numeric timestamps
-          const timestamps = (timestampResults || [])
-            .map((r: any) => {
-              const ts = parseLit(r.transcriptStart) || r.channelTs;
-              return ts;
-            })
-            .filter((ts) => ts != null && ts !== '')
-            .map((ts) => new Date(ts).getTime())
-            .filter((time) => !isNaN(time))
-            .sort((a, b) => a - b);
+      const batchResults = await this.perspective.querySparql(batchTimestampQuery);
 
-          const start = timestamps.length > 0 ? timestamps[0] : 0;
-          const end = timestamps.length > 0 ? timestamps[timestamps.length - 1] : 0;
+      // Group timestamps by subgroup ID
+      const timestampsBySg = new Map<string, number[]>();
+      for (const r of batchResults || []) {
+        const sgId = r.sg;
+        if (!sgId) continue;
+        const ts = parseLit(r.transcriptStart) || r.channelTs;
+        if (ts == null || ts === '') continue;
+        const time = new Date(ts).getTime();
+        if (isNaN(time)) continue;
+        if (!timestampsBySg.has(sgId)) timestampsBySg.set(sgId, []);
+        timestampsBySg.get(sgId)!.push(time);
+      }
 
-          return {
-            id: subgroup.id,
-            name: subgroup.name || '',
-            summary: subgroup.summary || '',
-            start,
-            end,
-          };
-        }),
-      );
+      const subgroups = Array.from(subgroupMap.values()).map((subgroup: any) => {
+        const timestamps = (timestampsBySg.get(subgroup.id) || []).sort((a, b) => a - b);
+        const start = timestamps.length > 0 ? timestamps[0] : 0;
+        const end = timestamps.length > 0 ? timestamps[timestamps.length - 1] : 0;
+
+        return {
+          id: subgroup.id,
+          name: subgroup.name || '',
+          summary: subgroup.summary || '',
+          timestamp: subgroup.timestamp || '',
+          start,
+          end,
+        };
+      });
 
       // Sort by actual content start time, not link creation time
       return subgroups.sort((a, b) => a.start - b.start);

--- a/packages/api/src/utils/parseLit.test.ts
+++ b/packages/api/src/utils/parseLit.test.ts
@@ -1,0 +1,41 @@
+import { parseLit } from './parseLit';
+
+describe('parseLit', () => {
+  it('returns empty string for undefined', () => {
+    expect(parseLit(undefined)).toBe('');
+  });
+
+  it('returns empty string for empty string', () => {
+    expect(parseLit('')).toBe('');
+  });
+
+  it('returns plain string as-is (Literal.fromUrl throws)', () => {
+    expect(parseLit('just a string')).toBe('just a string');
+  });
+
+  it('decodes literal:string: values', () => {
+    // Literal.from('hello').toUrl() produces a literal URL
+    // We test with the known format
+    const { Literal } = require('@coasys/ad4m');
+    const url = Literal.from('hello').toUrl();
+    expect(parseLit(url)).toBe('hello');
+  });
+
+  it('decodes URL-encoded literal strings', () => {
+    const { Literal } = require('@coasys/ad4m');
+    const url = Literal.from('hello world').toUrl();
+    expect(parseLit(url)).toBe('hello world');
+  });
+
+  it('extracts .data from JSON literal objects', () => {
+    const { Literal } = require('@coasys/ad4m');
+    const url = Literal.from({ data: 'extracted' }).toUrl();
+    expect(parseLit(url)).toBe('extracted');
+  });
+
+  it('JSON-stringifies objects without .data field', () => {
+    const { Literal } = require('@coasys/ad4m');
+    const url = Literal.from({ foo: 'bar' }).toUrl();
+    expect(parseLit(url)).toBe(JSON.stringify({ foo: 'bar' }));
+  });
+});

--- a/packages/api/src/utils/parseLit.ts
+++ b/packages/api/src/utils/parseLit.ts
@@ -1,0 +1,11 @@
+import { Literal } from '@coasys/ad4m';
+
+/** Parse a Literal-encoded value back to a plain string. */
+export function parseLit(val: string | undefined): string {
+  if (!val) return '';
+  try {
+    const result = Literal.fromUrl(val).get();
+    if (result && typeof result === 'object') return result.data ?? JSON.stringify(result);
+    return result;
+  } catch { return val; }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -947,8 +947,6 @@ importers:
         specifier: ^3.1.0
         version: 3.5.2(vite@4.5.14(@types/node@25.5.2)(sass@1.99.0)(terser@5.46.1))
 
-  views/nillion-file-store/dist: {}
-
   views/poll-view:
     dependencies:
       '@coasys/ad4m':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -255,8 +255,8 @@ importers:
         specifier: ^18.0.2
         version: 18.3.1
       ts-jest:
-        specifier: ^26.0.0
-        version: 26.5.6(jest@29.7.0(@types/node@25.5.2)(ts-node@10.9.2(@swc/core@1.15.24)(@swc/wasm@1.15.24)(@types/node@25.5.2)(typescript@5.9.3)))(typescript@5.9.3)
+        specifier: ^29
+        version: 29.4.9(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.14.54)(jest-util@29.7.0)(jest@29.7.0(@types/node@25.5.2)(ts-node@10.9.2(@swc/core@1.15.24)(@swc/wasm@1.15.24)(@types/node@25.5.2)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.0.4
         version: 5.9.3
@@ -340,6 +340,16 @@ importers:
       uuid:
         specifier: ^9.0.0
         version: 9.0.1
+    devDependencies:
+      '@types/jest':
+        specifier: ^29
+        version: 29.5.14
+      jest:
+        specifier: ^29
+        version: 29.7.0(@types/node@25.5.2)(ts-node@10.9.2(@swc/core@1.15.24)(@swc/wasm@1.15.24)(@types/node@25.5.2)(typescript@5.9.3))
+      ts-jest:
+        specifier: ^29
+        version: 29.4.9(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.14.54)(jest-util@29.7.0)(jest@29.7.0(@types/node@25.5.2)(ts-node@10.9.2(@swc/core@1.15.24)(@swc/wasm@1.15.24)(@types/node@25.5.2)(typescript@5.9.3)))(typescript@5.9.3)
 
   packages/comment-section:
     dependencies:
@@ -946,6 +956,8 @@ importers:
       vite-plugin-css-injected-by-js:
         specifier: ^3.1.0
         version: 3.5.2(vite@4.5.14(@types/node@25.5.2)(sass@1.99.0)(terser@5.46.1))
+
+  views/nillion-file-store/dist: {}
 
   views/poll-view:
     dependencies:
@@ -2821,10 +2833,6 @@ packages:
     resolution: {integrity: sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  '@jest/types@26.6.2':
-    resolution: {integrity: sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==}
-    engines: {node: '>= 10.14.2'}
-
   '@jest/types@29.6.3':
     resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -3850,9 +3858,6 @@ packages:
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
-
-  '@types/yargs@15.0.20':
-    resolution: {integrity: sha512-KIkX+/GgfFitlASYCGoSF+T4XRXhOubJLhkLVtSfsRTe9jWMmuM2g28zQ41BtPTG7TRBb2xHW+LCNVE9QR/vsg==}
 
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
@@ -7336,10 +7341,6 @@ packages:
   jest-transform-stub@2.0.0:
     resolution: {integrity: sha512-lspHaCRx/mBbnm3h4uMMS3R5aZzMwyNpNIJLXj4cEsV0mIUtS4IjYJLSoyjRCtnxb6RIGJ4NL2quZzfIeNhbkg==}
 
-  jest-util@26.6.2:
-    resolution: {integrity: sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==}
-    engines: {node: '>= 10.14.2'}
-
   jest-util@29.7.0:
     resolution: {integrity: sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -7692,6 +7693,9 @@ packages:
 
   lodash.ismatch@4.4.0:
     resolution: {integrity: sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==}
+
+  lodash.memoize@4.1.2:
+    resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -9931,13 +9935,32 @@ packages:
     resolution: {integrity: sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==}
     engines: {node: '>=8'}
 
-  ts-jest@26.5.6:
-    resolution: {integrity: sha512-rua+rCP8DxpA8b4DQD/6X2HQS8Zy/xzViVYfEs2OQu68tkCuKLV0Md8pmX55+W24uRIyAsf/BajRfxOs+R2MKA==}
-    engines: {node: '>= 10'}
+  ts-jest@29.4.9:
+    resolution: {integrity: sha512-LTb9496gYPMCqjeDLdPrKuXtncudeV1yRZnF4Wo5l3SFi0RYEnYRNgMrFIdg+FHvfzjCyQk1cLncWVqiSX+EvQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
-      jest: '>=26 <27'
-      typescript: '>=3.8 <5.0'
+      '@babel/core': '>=7.0.0-beta.0 <8'
+      '@jest/transform': ^29.0.0 || ^30.0.0
+      '@jest/types': ^29.0.0 || ^30.0.0
+      babel-jest: ^29.0.0 || ^30.0.0
+      esbuild: '*'
+      jest: ^29.0.0 || ^30.0.0
+      jest-util: ^29.0.0 || ^30.0.0
+      typescript: '>=4.3 <7'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@jest/transform':
+        optional: true
+      '@jest/types':
+        optional: true
+      babel-jest:
+        optional: true
+      esbuild:
+        optional: true
+      jest-util:
+        optional: true
 
   ts-loader@9.5.7:
     resolution: {integrity: sha512-/ZNrKgA3K3PtpMYOC71EeMWIloGw3IYEa5/t1cyz2r5/PyUwTXGzYJvcD3kfUvmhlfpz1rhV8B2O6IVTQ0avsg==}
@@ -10049,6 +10072,10 @@ packages:
   type-fest@0.8.1:
     resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
     engines: {node: '>=8'}
+
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
 
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
@@ -12904,14 +12931,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@jest/types@26.6.2':
-    dependencies:
-      '@types/istanbul-lib-coverage': 2.0.6
-      '@types/istanbul-reports': 3.0.4
-      '@types/node': 25.5.2
-      '@types/yargs': 15.0.20
-      chalk: 4.1.2
-
   '@jest/types@29.6.3':
     dependencies:
       '@jest/schemas': 29.6.3
@@ -13940,10 +13959,6 @@ snapshots:
   '@types/webxr@0.5.24': {}
 
   '@types/yargs-parser@21.0.3': {}
-
-  '@types/yargs@15.0.20':
-    dependencies:
-      '@types/yargs-parser': 21.0.3
 
   '@types/yargs@17.0.35':
     dependencies:
@@ -18319,15 +18334,6 @@ snapshots:
 
   jest-transform-stub@2.0.0: {}
 
-  jest-util@26.6.2:
-    dependencies:
-      '@jest/types': 26.6.2
-      '@types/node': 25.5.2
-      chalk: 4.1.2
-      graceful-fs: 4.2.11
-      is-ci: 2.0.0
-      micromatch: 4.0.8
-
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
@@ -18714,6 +18720,8 @@ snapshots:
   lodash.isequal@4.5.0: {}
 
   lodash.ismatch@4.4.0: {}
+
+  lodash.memoize@4.1.2: {}
 
   lodash.merge@4.6.2: {}
 
@@ -21249,20 +21257,26 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  ts-jest@26.5.6(jest@29.7.0(@types/node@25.5.2)(ts-node@10.9.2(@swc/core@1.15.24)(@swc/wasm@1.15.24)(@types/node@25.5.2)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.4.9(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.14.54)(jest-util@29.7.0)(jest@29.7.0(@types/node@25.5.2)(ts-node@10.9.2(@swc/core@1.15.24)(@swc/wasm@1.15.24)(@types/node@25.5.2)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
-      buffer-from: 1.1.2
       fast-json-stable-stringify: 2.1.0
+      handlebars: 4.7.9
       jest: 29.7.0(@types/node@25.5.2)(ts-node@10.9.2(@swc/core@1.15.24)(@swc/wasm@1.15.24)(@types/node@25.5.2)(typescript@5.9.3))
-      jest-util: 26.6.2
       json5: 2.2.3
-      lodash: 4.18.1
+      lodash.memoize: 4.1.2
       make-error: 1.3.6
-      mkdirp: 1.0.4
       semver: 7.7.4
+      type-fest: 4.41.0
       typescript: 5.9.3
-      yargs-parser: 20.2.9
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.29.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.29.0)
+      esbuild: 0.14.54
+      jest-util: 29.7.0
 
   ts-loader@9.5.7(typescript@5.9.3)(webpack@5.106.0):
     dependencies:
@@ -21378,6 +21392,8 @@ snapshots:
   type-fest@0.6.0: {}
 
   type-fest@0.8.1: {}
+
+  type-fest@4.41.0: {}
 
   type-is@1.6.18:
     dependencies:


### PR DESCRIPTION
## SPARQL Performance Quick Wins (Flux)

### 3. Replace FILTER NOT EXISTS with set-difference (MEDIUM IMPACT)
- Channel.unprocessedItems() now uses 3 simple queries + JS Set difference
- Query 1: all item IDs in channel  
- Query 2: all processed item IDs (items in subgroups)
- Query 3: full data for unprocessed items only (via VALUES clause)
- Eliminates O(N²) FILTER NOT EXISTS pattern in Oxigraph

### 4. Batch subgroup timestamp queries (LOW-MEDIUM IMPACT)
- Conversation.subgroupsData() now fetches timestamps for ALL subgroups in a single query using VALUES clause
- Eliminates N+1 query pattern (was: 1 query per subgroup for timestamps)
- Results grouped by subgroup ID in JS

### Notes
- Pre-existing type errors unchanged (SynergyItem/SynergyGroup type mismatches)
- See companion AD4M PR: https://github.com/coasys/ad4m/pull/794

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smarter timeline updates: incoming events now trigger targeted incremental or full refreshes with cooldown and escalation handling.

* **Refactor**
  * Reduced redundant work when computing unprocessed channel items for faster responses.
  * Batched subgroup timestamp fetching for quicker aggregation and grouping.

* **Tests**
  * Added tests for query/set-difference logic, batched timestamp queries, and predicate-based timeline update routing.

* **Chores**
  * Enabled API test config and CI steps to run the API test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->