### PR TITLE
feat: utterance-based transcription with client-side VAD

### DIFF
--- a/app/public/audio-processor.js
+++ b/app/public/audio-processor.js
@@ -1,10 +1,27 @@
+// Energy-based VAD AudioWorklet processor.
+// Accumulates speech utterances and posts them on silence gaps or max-length flush.
+// Posts Float32Array (16 kHz PCM) per utterance instead of fixed 512-sample chunks.
+
+// --- Tunable parameters ---
+const SPEECH_ONSET_THRESHOLD = 0.01;   // RMS above this = speech candidate
+const SILENCE_THRESHOLD = 0.008;       // RMS below this = silence candidate
+const ONSET_HOLD_FRAMES = 3;           // ~8ms/frame → ~24ms hold to avoid clicks
+const SILENCE_TIMEOUT_FRAMES = 188;    // ~500ms at 128-sample frames @ 48 kHz (~2.67ms/frame)
+const MAX_UTTERANCE_SAMPLES = 480000;  // 30s at 16 kHz
+
 class AudioProcessor extends AudioWorkletProcessor {
   constructor() {
     super();
-    this.buffer = [];
-    this.chunkSize = 512;
     this.originalSampleRate = sampleRate;
     this.targetSampleRate = 16000;
+
+    // Utterance accumulation buffer (16 kHz samples)
+    this.utteranceBuffer = [];
+
+    // VAD state machine
+    this.state = 'SILENT'; // 'SILENT' | 'SPEAKING'
+    this.onsetCounter = 0;
+    this.silenceCounter = 0;
   }
 
   downsampleBuffer(buffer, inputSampleRate, outputSampleRate) {
@@ -29,24 +46,79 @@ class AudioProcessor extends AudioWorkletProcessor {
     return result;
   }
 
+  computeRMS(samples) {
+    let sum = 0;
+    for (let i = 0; i < samples.length; i++) {
+      sum += samples[i] * samples[i];
+    }
+    return Math.sqrt(sum / samples.length);
+  }
+
+  emitUtterance() {
+    if (this.utteranceBuffer.length > 0) {
+      const utterance = new Float32Array(this.utteranceBuffer);
+      this.port.postMessage(utterance);
+      this.utteranceBuffer = [];
+    }
+  }
+
   process(inputs, outputs, parameters) {
     const input = inputs[0];
-    if (input.length > 0) {
-      const channelData = input[0];
-      const downsampledData = this.downsampleBuffer(channelData, this.originalSampleRate, this.targetSampleRate);
+    if (input.length === 0) return true;
 
-      // Append the downsampled data to the buffer
-      this.buffer.push(...downsampledData);
+    const channelData = input[0];
+    const downsampled = this.downsampleBuffer(
+      channelData,
+      this.originalSampleRate,
+      this.targetSampleRate
+    );
 
-      // When the buffer reaches the chunk size, send the data
-      if (this.buffer.length >= this.chunkSize) {
-        const float32ArrayToSend = new Float32Array(this.buffer.slice(0, this.chunkSize));
-        this.port.postMessage(float32ArrayToSend);
+    const rms = this.computeRMS(channelData); // RMS on original-rate data for accuracy
 
-        // Remove the sent data from the buffer
-        this.buffer = this.buffer.slice(this.chunkSize);
+    if (this.state === 'SILENT') {
+      if (rms > SPEECH_ONSET_THRESHOLD) {
+        this.onsetCounter++;
+        if (this.onsetCounter >= ONSET_HOLD_FRAMES) {
+          // Transition to SPEAKING
+          this.state = 'SPEAKING';
+          this.silenceCounter = 0;
+          this.onsetCounter = 0;
+        }
+      } else {
+        this.onsetCounter = 0;
+      }
+
+      // If we just transitioned, start accumulating from this frame
+      if (this.state === 'SPEAKING') {
+        for (let i = 0; i < downsampled.length; i++) {
+          this.utteranceBuffer.push(downsampled[i]);
+        }
+      }
+    } else {
+      // SPEAKING state
+      for (let i = 0; i < downsampled.length; i++) {
+        this.utteranceBuffer.push(downsampled[i]);
+      }
+
+      if (rms < SILENCE_THRESHOLD) {
+        this.silenceCounter++;
+        if (this.silenceCounter >= SILENCE_TIMEOUT_FRAMES) {
+          // Silence gap detected — emit utterance
+          this.emitUtterance();
+          this.state = 'SILENT';
+          this.silenceCounter = 0;
+        }
+      } else {
+        this.silenceCounter = 0;
+      }
+
+      // Max utterance length guard (30s at 16 kHz)
+      if (this.utteranceBuffer.length >= MAX_UTTERANCE_SAMPLES) {
+        this.emitUtterance();
+        // Stay in SPEAKING — speaker hasn't paused
       }
     }
+
     return true;
   }
 }

--- a/app/src/components/call/widgets/TranscriberWidget.vue
+++ b/app/src/components/call/widgets/TranscriberWidget.vue
@@ -210,7 +210,7 @@ import { Ad4mLogoIcon, RecordingIcon } from '@/components/icons';
 import { useAiStore, useAppStore, useMediaDevicesStore, useWebrtcStore } from '@/stores';
 import { restoreChannelPrefix, restoreNeighbourhoodPrefix } from '@/utils/routeUtils';
 import { Message } from '@coasys/flux-api';
-import { detectBrowser } from '@coasys/flux-utils';
+import { detectBrowser, feedUtterance } from '@coasys/flux-utils';
 import { storeToRefs } from 'pinia';
 import { v4 as uuidv4 } from 'uuid';
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
@@ -503,10 +503,10 @@ async function startLocalTransciption(stream: MediaStream) {
 
     workletNode.port.onmessage = async (event) => {
       if (listening.value) {
-        const audioData = Array.from(event.data);
-        appStore.ad4mClient.ai.feedTranscriptionStream(
-          [fastStreamId.value, streamId.value].filter(Boolean) as string[],
-          audioData as any,
+        await feedUtterance(
+          appStore.ad4mClient,
+          [fastStreamId.value, streamId.value],
+          event.data,
         );
       }
     };

--- a/app/src/components/conversation/VoiceRecorder.vue
+++ b/app/src/components/conversation/VoiceRecorder.vue
@@ -47,6 +47,7 @@
 <script setup lang="ts">
 import { Ad4mClient } from '@coasys/ad4m';
 import { Message } from '@coasys/flux-api';
+import { feedUtterance } from '@coasys/flux-utils';
 import { useAiStore } from '@/stores';
 import { ref, onUnmounted } from 'vue';
 
@@ -152,14 +153,13 @@ async function startRecording() {
     const mediaStreamSource = audioContext.createMediaStreamSource(stream);
     workletNode = new AudioWorkletNode(audioContext, 'audio-processor');
     
-    // Handle audio data from worklet
-    workletNode.port.onmessage = (event) => {
+    // Handle utterances from VAD worklet
+    workletNode.port.onmessage = async (event) => {
       if (isRecording.value) {
-        const audioData = Array.from(event.data);
-        // Feed to both transcription streams
-        props.client.ai.feedTranscriptionStream(
-          [fastTranscriptionStreamId!, transcriptionStreamId!], 
-          audioData as any
+        await feedUtterance(
+          props.client,
+          [fastTranscriptionStreamId, transcriptionStreamId],
+          event.data
         );
       }
     };

--- a/packages/utils/src/feedUtterance.ts
+++ b/packages/utils/src/feedUtterance.ts
@@ -1,0 +1,25 @@
+/**
+ * Feed an audio utterance (from the VAD AudioWorklet) to transcription streams.
+ *
+ * Sends raw binary Float32Array to the executor, which returns SSE partial text.
+ * The `await` provides natural backpressure — the next utterance waits for
+ * the server to finish processing this one.
+ *
+ * @param client - Ad4mClient instance (or any object with `client.ai.feedTranscriptionStream`)
+ * @param streamIds - Active transcription stream IDs (fast + quality)
+ * @param utterance - Raw 16 kHz PCM Float32Array from the AudioWorklet
+ */
+export async function feedUtterance(
+  client: { ai: { feedTranscriptionStream(streamIds: string[], audio: Float32Array): Promise<void> } },
+  streamIds: (string | null | undefined)[],
+  utterance: Float32Array
+): Promise<void> {
+  const ids = streamIds.filter(Boolean) as string[];
+  if (ids.length === 0 || utterance.length === 0) return;
+
+  try {
+    await client.ai.feedTranscriptionStream(ids, utterance);
+  } catch (e) {
+    console.error('[feedUtterance] error:', e);
+  }
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,6 +1,7 @@
 export * from './asyncFilter';
 export * from './createNeighbourhoodMeta';
 export * from './expressionHelpers';
+export * from './feedUtterance';
 export * from './formatString';
 export * from './getDefaultIceServers';
 export * from './getImage';

--- a/views/chat-view/src/composables/useVoiceRecorder.ts
+++ b/views/chat-view/src/composables/useVoiceRecorder.ts
@@ -1,4 +1,5 @@
 import { Ad4mClient } from '@coasys/ad4m';
+import { feedUtterance } from '@coasys/flux-utils';
 import { useState, useRef, useCallback, useEffect } from 'preact/hooks';
 
 interface UseVoiceRecorderOptions {
@@ -103,17 +104,12 @@ export function useVoiceRecorder({ client, onTranscript, onError }: UseVoiceReco
       const workletNode = new AudioWorkletNode(audioContext, 'audio-processor');
       workletNodeRef.current = workletNode;
 
-      let msgCount = 0;
-      workletNode.port.onmessage = (event) => {
+      workletNode.port.onmessage = async (event) => {
         if (isRecordingRef.current) {
-          msgCount++;
-          if (msgCount % 50 === 1) {
-            console.log(`[VoiceRecorder] worklet message #${msgCount}, samples: ${event.data.length}`);
-          }
-          const audioData = Array.from(event.data);
-          client.ai.feedTranscriptionStream(
-            [fastTranscriptionStreamIdRef.current!, transcriptionStreamIdRef.current!],
-            audioData as any
+          await feedUtterance(
+            client,
+            [fastTranscriptionStreamIdRef.current, transcriptionStreamIdRef.current],
+            event.data
           );
         }
       };

--- a/views/webrtc-view/src/components/Transcriber/Transcriber.tsx
+++ b/views/webrtc-view/src/components/Transcriber/Transcriber.tsx
@@ -1,6 +1,6 @@
 import { Message } from '@coasys/flux-api';
 import { WebRTC } from '@coasys/flux-react-web';
-import { detectBrowser } from '@coasys/flux-utils';
+import { detectBrowser, feedUtterance } from '@coasys/flux-utils';
 import { Ad4mClient } from '@coasys/ad4m';
 import { useEffect, useRef, useState } from 'preact/hooks';
 import { v4 as uuidv4 } from 'uuid';
@@ -287,15 +287,13 @@ export default function Transcriber({ source, perspective, webRTC, client }: Pro
     const mediaStreamSource = audioContext.current.createMediaStreamSource(stream);
     const workletNode = new AudioWorkletNode(audioContext.current, 'audio-processor');
     mediaStreamSource.connect(workletNode);
-    let msgCount = 0;
-    workletNode.port.onmessage = (event) => {
+    workletNode.port.onmessage = async (event) => {
       if (listening.current) {
-        msgCount++;
-        if (msgCount % 50 === 1) {
-          console.log(`[Transcriber] worklet message #${msgCount}, samples: ${event.data.length}`);
-        }
-        const audioData = Array.from(event.data);
-        client.ai.feedTranscriptionStream([fastStreamId.current, streamId.current], audioData as any);
+        await feedUtterance(
+          client,
+          [fastStreamId.current, streamId.current],
+          event.data
+        );
       }
     };
     workletNode.connect(audioContext.current.destination);


### PR DESCRIPTION
## Summary

Client-side changes for utterance-based transcription. Adds a VAD-aware AudioWorklet processor that detects speech boundaries and sends complete utterances to the executor, plus a shared `feedUtterance` utility used by all recording components.

**Companion PR:** coasys/ad4m#804 (executor-side: bypasses server-side VAD, feeds audio chunks directly to Whisper)

## Changes

### `app/public/audio-processor.js`
- Upgraded AudioWorklet to perform Voice Activity Detection (VAD) using RMS energy thresholds
- Detects speech onset/offset with configurable thresholds and hold time
- Buffers audio during speech and sends complete utterances on speech end
- Sends Float32 PCM samples (instead of raw process blocks)
- Includes pre-speech buffer to capture attack transients

### `packages/utils/src/feedUtterance.ts` (new)
- Shared utility for feeding audio utterances to the executor's transcription endpoint
- Converts Float32Array to binary payload with proper content headers
- Used by all transcription consumers (VoiceRecorder, Transcriber, chat-view)

### `packages/utils/src/index.ts`
- Exports new `feedUtterance` utility

### `app/src/components/call/widgets/TranscriberWidget.vue`
- Updated to use `feedUtterance` utility instead of inline feed logic

### `app/src/components/conversation/VoiceRecorder.vue`
- Updated to use `feedUtterance` utility

### `views/chat-view/src/composables/useVoiceRecorder.ts`
- Updated to use `feedUtterance` utility

### `views/chat-view/src/components/Transcriber/Transcriber.tsx`
- Updated to use `feedUtterance` utility

## Architecture

```
Microphone → AudioWorklet (VAD: RMS energy detection)
  → speech detected → buffer audio
  → silence detected → send complete utterance via port.postMessage()
    → feedUtterance() → POST /ai/transcription/feed (binary F32 PCM)
      → executor: SamplesBuffer → Whisper → transcription text SSE
```