### PR TITLE
feat(channel): graph-rooted Channel model (named graphs)

### DIFF
--- a/packages/api/src/channel/index.ts
+++ b/packages/api/src/channel/index.ts
@@ -21,7 +21,7 @@ const {
   SUBGROUP_ITEM,
 } = community;
 
-@Model({ name: 'Channel' })
+@Model({ name: 'Channel', graph: true })
 export class Channel extends Ad4mModel {
   @Flag({ through: ENTRY_TYPE, value: EntryType.Channel })
   type: string;


### PR DESCRIPTION
## Summary

Marks the `Channel` model with `@Model({ name: "Channel", graph: true })` so each channel instance's triples are stored in an isolated named graph within the perspective's Oxigraph store.

## What This Enables

- **Scoped queries**: Querying a channel's data only scans its named graph, not the entire perspective
- **Bulk deletion**: Removing a channel deletes its entire named graph in one operation
- **Subscription filtering**: UI components subscribed to a specific channel's graph won't re-render when unrelated channels change

## Change

```diff
- @Model({ name: "Channel" })
+ @Model({ name: "Channel", graph: true })
```

In `packages/api/src/channel/index.ts`.

## Graph IRI Convention

Each channel instance gets a named graph at:
```
ad4m://graph/<channelBaseExpression>
```

All triples for that channel (name, description, views, members, etc.) are stored within this graph rather than the perspective's default graph.

## Dependencies

- **Requires**: coasys/ad4m#812 (feat/subject-class-named-graphs) — the AD4M SDK/executor changes that implement the named graphs infrastructure

## Testing

- TypeScript compilation passes (`tsc --noEmit`)
- Existing Flux tests unaffected (graph-rooted is backward-compatible — old data in default graph is still queryable)