### PR TITLE
Migrate Post/Community image transforms to SHACL DSL

### DIFF
--- a/packages/api/src/community/index.ts
+++ b/packages/api/src/community/index.ts
@@ -1,4 +1,4 @@
-import { Ad4mModel, HasMany, Flag, Model, Property } from '@coasys/ad4m';
+import { Ad4mModel, HasMany, Flag, Model, Property, fileToDataUri } from '@coasys/ad4m';
 import { community, languages } from '@coasys/flux-constants';
 import { EntryType } from '@coasys/flux-types';
 import Channel from '../channel';
@@ -26,16 +26,14 @@ export class Community extends Ad4mModel {
   @Property({
     through: IMAGE,
     resolveLanguage: FILE_STORAGE_LANGUAGE,
-    transform: (data) =>
-      data?.data_base64 ? `data:${data?.file_type || 'image/png'};base64,${data?.data_base64}` : data,
+    transform: fileToDataUri,
   })
   image: string | FileData;
 
   @Property({
     through: THUMBNAIL,
     resolveLanguage: FILE_STORAGE_LANGUAGE,
-    transform: (data) =>
-      data?.data_base64 ? `data:${data?.file_type || 'image/png'};base64,${data?.data_base64}` : data,
+    transform: fileToDataUri,
   })
   thumbnail: string | FileData;
 

--- a/packages/api/src/post/index.ts
+++ b/packages/api/src/post/index.ts
@@ -1,4 +1,4 @@
-import { Ad4mModel, HasMany, Flag, Model, Property } from '@coasys/ad4m';
+import { Ad4mModel, HasMany, Flag, Model, Property, fileToDataUri } from '@coasys/ad4m';
 import { community, languages } from '@coasys/flux-constants';
 
 import { EntryType } from '@coasys/flux-types';
@@ -21,7 +21,7 @@ export class Post extends Ad4mModel {
   @Property({
     through: IMAGE,
     resolveLanguage: FILE_STORAGE_LANGUAGE,
-    transform: (data) => (data ? `data:image/png;base64,${data?.data_base64}` : undefined),
+    transform: fileToDataUri,
   })
   image: string;
 


### PR DESCRIPTION
## Summary

Companion PR for [coasys/ad4m#825](https://github.com/coasys/ad4m/pull/825), which replaces JS lambda \`transform\` decorator options with a serializable SHACL-AF NodeExpression DSL evaluated server-side in the Rust executor.

The Post and Community \`@Property\` transforms were JS lambdas that converted FileData → \`data:\` URI — exactly the behavior of the new \`fileToDataUri\` built-in expression. Replace the three ad-hoc client-side lambdas with the canonical built-in.

- [packages/api/src/post/index.ts](packages/api/src/post/index.ts) — \`image\` transform
- [packages/api/src/community/index.ts](packages/api/src/community/index.ts) — \`image\` and \`thumbnail\` transforms

The Flux CI [auto-detects matching-branch in coasys/ad4m](.github/workflows/build.yaml) and builds against it, so this PR will compile/test against the SHACL DSL ad4m branch.

## Test plan

- [ ] CI build passes
- [ ] \`@coasys/flux-api\` vitest suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated file data transformation logic into a shared utility for improved code maintainability and consistency across the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coasys/flux/pull/598?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->