### PR TITLE
feat(api): typed SPARQL bindings for raw query methods

### DIFF
--- a/packages/api/src/channel/index.ts
+++ b/packages/api/src/channel/index.ts
@@ -1,5 +1,4 @@
-import { Ad4mModel, HasMany, HasManyMethods, Flag, Literal, LinkQuery, Model, Property, PerspectiveProxy } from '@coasys/ad4m';
-import { parseLit } from '../utils/parseLit';
+import { Ad4mModel, HasMany, HasManyMethods, Flag, Literal, LinkQuery, Model, Property, PerspectiveProxy, parseLit, parseSparqlCount, CountBinding } from '@coasys/ad4m';
 import { community } from '@coasys/flux-constants';
 import { EntryType } from '@coasys/flux-types';
 import { SynergyGroup, SynergyItem, ItemType, icons } from '@coasys/flux-utils';
@@ -20,6 +19,37 @@ const {
   FLUX_PARTICIPANT,
   SUBGROUP_ITEM,
 } = community;
+
+// ---------------------------------------------------------------------------
+// SPARQL binding shapes — typed via `querySparql<T>()` so call sites lose the
+// `binding: any` annotations and gain compile-time field checks.
+// ---------------------------------------------------------------------------
+
+interface IdBinding {
+  id: string;
+}
+
+interface ChannelItemBinding {
+  id: string;
+  author: string;
+  timestamp: string;
+  type: string;
+  body?: string;
+  title?: string;
+  taskName?: string;
+  transcriptStart?: string;
+}
+
+interface RecentConversationBinding {
+  channelId: string;
+  isConv: string;
+  conversationId?: string;
+}
+
+interface PinnedConversationBinding {
+  channelId: string;
+  conversationId?: string;
+}
 
 @Model({ name: 'Channel' })
 export class Channel extends Ad4mModel {
@@ -85,9 +115,9 @@ export class Channel extends Ad4mModel {
         ORDER BY ?timestamp
       `;
 
-      const sparqlResult = await this.perspective.querySparql(sparqlQuery);
+      const sparqlResult = await this.perspective.querySparql<ChannelItemBinding[]>(sparqlQuery);
 
-      const mapped = (sparqlResult || []).map((binding: any) => {
+      const mapped = (sparqlResult || []).map((binding) => {
         let text = '';
         let type: ItemType = 'Message';
         const itemType = binding.type;
@@ -113,7 +143,7 @@ export class Channel extends Ad4mModel {
         };
       });
       // Re-sort by effective timestamp since transcriptStart may differ from link timestamp
-      return mapped.sort((a: SynergyItem, b: SynergyItem) => a.timestamp.localeCompare(b.timestamp));
+      return mapped.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
     } catch (error) {
       console.error('Error getting all channel items:', error);
       return [];
@@ -152,14 +182,14 @@ export class Channel extends Ad4mModel {
       // an item to appear in allItems but not processedSet (or vice-versa).
       // The final VALUES query re-verifies channel membership to mitigate this.
       const [allItemsResult, processedResult] = await Promise.all([
-        this.perspective.querySparql(allItemsQuery),
-        this.perspective.querySparql(processedQuery),
+        this.perspective.querySparql<IdBinding[]>(allItemsQuery),
+        this.perspective.querySparql<IdBinding[]>(processedQuery),
       ]);
 
-      const processedSet = new Set((processedResult || []).map((r: any) => r.id));
+      const processedSet = new Set((processedResult || []).map((r) => r.id));
       const unprocessedIds = (allItemsResult || [])
-        .map((r: any) => r.id)
-        .filter((id: string) => id && !processedSet.has(id));
+        .map((r) => r.id)
+        .filter((id) => id && !processedSet.has(id));
 
       if (unprocessedIds.length === 0) return [];
 
@@ -183,17 +213,17 @@ export class Channel extends Ad4mModel {
         ORDER BY ?timestamp
       `;
 
-      const sparqlResult = await this.perspective.querySparql(dataQuery);
+      const sparqlResult = await this.perspective.querySparql<ChannelItemBinding[]>(dataQuery);
 
       // Deduplicate by id
-      const itemMap = new Map<string, any>();
+      const itemMap = new Map<string, ChannelItemBinding>();
       for (const binding of sparqlResult || []) {
         const id = binding.id;
         if (!id || itemMap.has(id)) continue;
         itemMap.set(id, binding);
       }
 
-      const mapped = Array.from(itemMap.values()).map((binding: any) => {
+      const mapped = Array.from(itemMap.values()).map((binding) => {
         let text = '';
         let type: ItemType = 'Message';
         const itemType = binding.type;
@@ -238,9 +268,8 @@ export class Channel extends Ad4mModel {
         }
       `;
 
-      const sparqlResult = await this.perspective.querySparql(sparqlQuery);
-      const countValue = sparqlResult?.[0]?.count;
-      return countValue ? parseInt(countValue, 10) : 0;
+      const sparqlResult = await this.perspective.querySparql<CountBinding[]>(sparqlQuery);
+      return parseSparqlCount(sparqlResult);
     } catch (error) {
       console.error('Error getting total item count:', error);
       return 0;
@@ -274,7 +303,7 @@ export class Channel extends Ad4mModel {
     `;
 
     try {
-      const results = await perspective.querySparql(sparql);
+      const results = await perspective.querySparql<RecentConversationBinding[]>(sparql);
 
       // Filter to only conversation channels and dedup
       const channelMap = new Map<string, { channelId: string; conversationId?: string; lastActivity?: string }>();
@@ -338,7 +367,7 @@ export class Channel extends Ad4mModel {
     `;
 
     try {
-      const results = await perspective.querySparql(sparql);
+      const results = await perspective.querySparql<PinnedConversationBinding[]>(sparql);
       // Deduplicate by channelId
       const seen = new Map<string, { channelId: string; conversationId?: string }>();
       for (const r of results || []) {

--- a/packages/api/src/conversation-subgroup/index.ts
+++ b/packages/api/src/conversation-subgroup/index.ts
@@ -1,11 +1,36 @@
-import { Model, Ad4mModel, Flag, HasMany, Property, Literal } from '@coasys/ad4m';
-import { parseLit } from '../utils/parseLit';
+import { Model, Ad4mModel, Flag, HasMany, Property, Literal, parseLit } from '@coasys/ad4m';
 import Topic, { TopicWithRelevance } from '../topic';
 import SemanticRelationship from '../semantic-relationship';
 import { SynergyTopic, SynergyItem, ItemType, icons } from '@coasys/flux-utils';
 import { community } from '@coasys/flux-constants';
 
 const { FLUX_PARTICIPANT, SUBGROUP_ITEM } = community;
+
+// SPARQL binding shapes — typed via `querySparql<T>()`.
+interface ItemIdBinding { item: string }
+interface DidBinding { did: string }
+interface TopicBinding { topicBase: string; topicNameRaw?: string }
+interface TopicRelevanceBinding extends TopicBinding { relevanceRaw?: string }
+interface SubgroupItemBinding {
+  id: string;
+  type: string;
+  author: string;
+  timestamp: string;
+  body?: string;
+  title?: string;
+  taskName?: string;
+  transcriptStart?: string;
+  channelTs?: string;
+}
+interface SubgroupItem {
+  id: string;
+  type: string;
+  author: string;
+  channelTimestamp: string;
+  messageBody: string;
+  postTitle: string;
+  taskName: string;
+}
 
 @Model({ name: 'ConversationSubgroup' })
 export default class ConversationSubgroup extends Ad4mModel {
@@ -41,12 +66,12 @@ export default class ConversationSubgroup extends Ad4mModel {
       `;
 
       const [itemsResult, participantsResult] = await Promise.all([
-        this.perspective.querySparql(itemsQuery),
-        this.perspective.querySparql(participantsQuery),
+        this.perspective.querySparql<ItemIdBinding[]>(itemsQuery),
+        this.perspective.querySparql<DidBinding[]>(participantsQuery),
       ]);
 
       const totalItems = itemsResult?.length || 0;
-      const participants = (participantsResult || []).map((r: any) => r.did).filter(Boolean);
+      const participants = (participantsResult || []).map((r) => r.did).filter(Boolean);
       return { totalItems, participants };
     } catch (error) {
       console.error('Error getting subgroup stats:', error);
@@ -68,10 +93,10 @@ export default class ConversationSubgroup extends Ad4mModel {
         }
       `;
 
-      const sparqlResult = await this.perspective.querySparql(sparqlQuery);
+      const sparqlResult = await this.perspective.querySparql<TopicBinding[]>(sparqlQuery);
 
       // Deduplicate by topicBase
-      const uniqueTopics = new Map<string, any>();
+      const uniqueTopics = new Map<string, { topicBase: string; topicName: string }>();
       for (const binding of sparqlResult || []) {
         const topicBase = binding.topicBase;
         if (topicBase && !uniqueTopics.has(topicBase)) {
@@ -120,11 +145,11 @@ export default class ConversationSubgroup extends Ad4mModel {
         ORDER BY ?timestamp
       `;
 
-      const sparqlResult = await this.perspective.querySparql(sparqlQuery);
+      const sparqlResult = await this.perspective.querySparql<SubgroupItemBinding[]>(sparqlQuery);
 
       // Collect items — keep duplicate IDs so the view can detect and clean them up
-      const items: any[] = [];
-      const seen = new Map<string, any>();
+      const items: SubgroupItem[] = [];
+      const seen = new Map<string, SubgroupItem>();
       for (const binding of sparqlResult || []) {
         const id = binding.id;
         if (!id) continue;
@@ -132,7 +157,7 @@ export default class ConversationSubgroup extends Ad4mModel {
         // Coalesce OPTIONAL fields from multiple SPARQL rows for same id
         if (seen.has(id)) {
           // Merge optional fields from this binding into the existing item
-          const existing = seen.get(id);
+          const existing = seen.get(id)!;
           const transcriptStart = parseLit(binding.transcriptStart);
           const channelTs = binding.channelTs;
           const fallbackTs = binding.timestamp;
@@ -152,7 +177,7 @@ export default class ConversationSubgroup extends Ad4mModel {
         const fallbackTs = binding.timestamp;
         const channelTimestamp = transcriptStart || channelTs || fallbackTs;
 
-        const item = {
+        const item: SubgroupItem = {
           id,
           type: binding.type,
           author: binding.author,
@@ -166,12 +191,12 @@ export default class ConversationSubgroup extends Ad4mModel {
       }
 
       // Sort by the effective timestamp (transcriptStart || channelTs || fallback)
-      const sorted = items.sort((a: any, b: any) => {
+      const sorted = items.sort((a, b) => {
         const tsA = a.channelTimestamp || '';
         const tsB = b.channelTimestamp || '';
         return tsA < tsB ? -1 : tsA > tsB ? 1 : 0;
       });
-      return sorted.map((item: any) => {
+      return sorted.map((item) => {
         let text = '';
         let type: ItemType = 'Message';
 
@@ -215,10 +240,10 @@ export default class ConversationSubgroup extends Ad4mModel {
         }
       `;
 
-      const sparqlResult = await this.perspective.querySparql(sparqlQuery);
+      const sparqlResult = await this.perspective.querySparql<TopicRelevanceBinding[]>(sparqlQuery);
 
       // Deduplicate by topicBase
-      const uniqueTopics = new Map<string, any>();
+      const uniqueTopics = new Map<string, { topicBase: string; topicName: string; relevance: string }>();
       for (const binding of sparqlResult || []) {
         const topicBase = binding.topicBase;
         if (topicBase && !uniqueTopics.has(topicBase)) {

--- a/packages/api/src/conversation/index.ts
+++ b/packages/api/src/conversation/index.ts
@@ -1,15 +1,37 @@
-import { Ad4mModel, Ad4mClient, Flag, HasMany, HasManyMethods, Link, Literal, Model, Property } from '@coasys/ad4m';
+import { Ad4mModel, Ad4mClient, Flag, HasMany, HasManyMethods, Link, Literal, Model, Property, parseLit } from '@coasys/ad4m';
 
-import { parseLit } from '../utils/parseLit';
 import { getProfile, Topic } from '@coasys/flux-api';
 import { ProcessingState, Profile } from '@coasys/flux-types';
 import { SynergyGroup, SynergyItem, SynergyTopic } from '@coasys/flux-utils';
 import ConversationSubgroup from '../conversation-subgroup';
+import { TopicWithRelevance } from '../topic';
 import { formatTranscriptMarkdown } from './export';
 import { ensureLLMTasks, LLMTaskWithExpectedOutputs } from './LLMutils';
 import { createEmbedding, removeEmbedding } from './util';
 import { community } from '@coasys/flux-constants';
 const { FLUX_PARTICIPANT, SUBGROUP_ITEM } = community;
+
+// SPARQL binding shapes — typed via `querySparql<T>()`.
+interface SgBinding { sg: string }
+interface DidBinding { did: string }
+interface TopicBinding { topicBase: string; topicNameRaw?: string }
+interface SubgroupRowBinding {
+  id: string;
+  timestamp: string;
+  nameRaw?: string;
+  summaryRaw?: string;
+}
+interface SubgroupTimestampBinding {
+  sg: string;
+  transcriptStart?: string;
+  channelTs?: string;
+}
+interface SubgroupRow {
+  id: string;
+  timestamp: string;
+  name: string;
+  summary: string;
+}
 
 @Model({ name: 'Conversation' })
 export class Conversation extends Ad4mModel {
@@ -49,12 +71,12 @@ export class Conversation extends Ad4mModel {
       `;
 
       const [subgroupsResult, participantsResult] = await Promise.all([
-        this.perspective.querySparql(subgroupsQuery),
-        this.perspective.querySparql(participantsQuery),
+        this.perspective.querySparql<SgBinding[]>(subgroupsQuery),
+        this.perspective.querySparql<DidBinding[]>(participantsQuery),
       ]);
 
       const totalSubgroups = subgroupsResult?.length || 0;
-      const participants = (participantsResult || []).map((r: any) => r.did).filter(Boolean);
+      const participants = (participantsResult || []).map((r) => r.did).filter(Boolean);
       return { totalSubgroups, participants };
     } catch (error) {
       console.error('Error getting conversation stats:', error);
@@ -81,10 +103,10 @@ export class Conversation extends Ad4mModel {
         }
       `;
 
-      const sparqlResult = await this.perspective.querySparql(sparqlQuery);
+      const sparqlResult = await this.perspective.querySparql<TopicBinding[]>(sparqlQuery);
 
       // Deduplicate by topicBase
-      const uniqueTopics = new Map<string, any>();
+      const uniqueTopics = new Map<string, { topicBase: string; topicName: string }>();
       for (const binding of sparqlResult || []) {
         const topicBase = binding.topicBase;
         if (topicBase && !uniqueTopics.has(topicBase)) {
@@ -132,10 +154,10 @@ export class Conversation extends Ad4mModel {
         ORDER BY ?timestamp
       `;
 
-      const sparqlResult = await this.perspective.querySparql(sparqlQuery);
+      const sparqlResult = await this.perspective.querySparql<SubgroupRowBinding[]>(sparqlQuery);
 
       // Deduplicate by id
-      const subgroupMap = new Map<string, any>();
+      const subgroupMap = new Map<string, SubgroupRow>();
       for (const binding of sparqlResult || []) {
         const id = binding.id;
         if (id && !subgroupMap.has(id)) {
@@ -167,7 +189,7 @@ export class Conversation extends Ad4mModel {
         }
       `;
 
-      const batchResults = await this.perspective.querySparql(batchTimestampQuery);
+      const batchResults = await this.perspective.querySparql<SubgroupTimestampBinding[]>(batchTimestampQuery);
 
       // Group timestamps by subgroup ID
       const timestampsBySg = new Map<string, number[]>();
@@ -182,8 +204,8 @@ export class Conversation extends Ad4mModel {
         timestampsBySg.get(sgId)!.push(time);
       }
 
-      const subgroups = Array.from(subgroupMap.values()).map((subgroup: any) => {
-        const timestamps = (timestampsBySg.get(subgroup.id) || []).sort((a: number, b: number) => a - b);
+      const subgroups = Array.from(subgroupMap.values()).map((subgroup) => {
+        const timestamps = (timestampsBySg.get(subgroup.id) || []).sort((a, b) => a - b);
         const start = timestamps.length > 0 ? timestamps[0] : 0;
         const end = timestamps.length > 0 ? timestamps[timestamps.length - 1] : 0;
 
@@ -279,24 +301,25 @@ export class Conversation extends Ad4mModel {
     isNewGroup?: boolean,
   ) {
     const { topics } = await ensureLLMTasks(this.perspective.ai);
-    let currentTopics = (await group.topicsWithRelevance()) as any;
-    let currentNewTopics = await LLMTaskWithExpectedOutputs(
+    const currentTopics: TopicWithRelevance[] = await group.topicsWithRelevance();
+    interface LLMTopic { n: string; rel: number }
+    let currentNewTopics: LLMTopic[] = await LLMTaskWithExpectedOutputs(
       topics,
       {
-        topics: currentTopics.map((t: any) => ({ n: t.name, rel: t.relevance })),
+        topics: currentTopics.map((t) => ({ n: t.name, rel: t.relevance })),
         messages: newMessages,
       },
       this.perspective.ai,
     );
 
     // Filter out topics with empty/null/undefined names to prevent Literal conversion errors
-    currentNewTopics = currentNewTopics.filter((topic: any) => topic.n && topic.n.trim() !== '');
+    currentNewTopics = currentNewTopics.filter((topic) => topic.n && topic.n.trim() !== '');
 
     const topicMatches = await Topic.findAll(this.perspective, {
-      where: { topic: currentNewTopics.map((topic: any) => topic.n) },
+      where: { topic: currentNewTopics.map((topic) => topic.n) },
     });
     await Promise.all(
-      currentNewTopics.map((topic: any) => {
+      currentNewTopics.map((topic) => {
         const existingTopic = topicMatches.find((t) => t.topic == topic.n);
         return group.updateTopicWithRelevance(topic.n, topic.rel, isNewGroup ?? false, existingTopic ?? null, batchId);
       }),

--- a/packages/api/src/utils/parseLit.ts
+++ b/packages/api/src/utils/parseLit.ts
@@ -1,11 +1,9 @@
-import { Literal } from '@coasys/ad4m';
-
-/** Parse a Literal-encoded value back to a plain string. */
-export function parseLit(val: string | undefined): string {
-  if (!val) return '';
-  try {
-    const result = Literal.fromUrl(val).get();
-    if (result && typeof result === 'object') return result.data ?? JSON.stringify(result);
-    return result;
-  } catch { return val; }
-}
+/**
+ * @deprecated Import `parseLit` from `@coasys/ad4m` directly (see SparqlBindings).
+ *
+ * This re-export remains for backward compatibility with code that imports
+ * from `'../utils/parseLit'`. New call sites should import directly from
+ * `@coasys/ad4m`, which also exposes `parseLitNumber`, `parseLitBoolean`,
+ * `parseSparqlCount`, and the `LinkBinding`/`CountBinding` types.
+ */
+export { parseLit } from '@coasys/ad4m';


### PR DESCRIPTION
## Summary

Companion to coasys/ad4m PR #831. Annotates each raw-SPARQL method in `Channel`, `Conversation`, and `ConversationSubgroup` with explicit binding interfaces via the new `querySparql<T>()` generic, eliminating `binding: any` throughout and adding compile-time checks for binding field names and types.

Covered methods (12 total):
- **Channel** — `allItems`, `unprocessedItems`, `totalItemCount`, `recentConversations`, `pinnedConversations`
- **Conversation** — `stats`, `topics`, `subgroupsData`
- **ConversationSubgroup** — `stats`, `topics`, `itemsData`, `topicsWithRelevance`

Also:
- `Channel.totalItemCount` switched to the new `parseSparqlCount(CountBinding[])` helper from `@coasys/ad4m`
- `(await group.topicsWithRelevance()) as any` in `Conversation.updateGroupTopics` replaced with the actual `TopicWithRelevance[]` type plus a local `LLMTopic` interface for downstream `.map`/`.filter` callbacks
- `packages/api/src/utils/parseLit.ts` becomes a thin re-export of `@coasys/ad4m`'s `parseLit` — existing `../utils/parseLit` imports keep working; new sites can pick up `parseLitNumber` / `parseLitBoolean` directly from core

## Base branch

**Staggered against `refactor/typescript-strictness`** — depends on coasys/ad4m PR #831 for `querySparql<T>`, `SparqlBindings`, and the typed `parseLit` family. Will need to be retargeted to `dev` once the parent branch lands.

## Test plan

- [x] `npx tsc --noEmit` in `packages/api` is clean except for one pre-existing test-mock issue (`channel-rename.test.ts:150` — incomplete `PerspectiveProxy` mock, unrelated)
- [ ] Full Flux app `vue-tsc` + dev server smoke once ad4m PR lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)