### PR TITLE
fix: add missing @coasys/ad4m dependency to comment-section

### DIFF
--- a/packages/comment-section/package.json
+++ b/packages/comment-section/package.json
@@ -25,6 +25,7 @@
     "dist"
   ],
   "dependencies": {
+    "@coasys/ad4m": "0.11.1",
     "@coasys/flux-editor": "workspace:*",
     "@coasys/flux-types": "workspace:*",
     "@coasys/flux-ui": "workspace:*",


### PR DESCRIPTION
# Fix: Add missing `@coasys/ad4m` dependency to `flux-comment-section`

## Problem

`@coasys/flux-comment-section` was importing from `@coasys/ad4m` without declaring it as an explicit dependency. This caused resolution issues when the package couldn't reliably inherit the correct version transitively.

## Fix

Added `@coasys/ad4m` as a direct dependency in `packages/comment-section/package.json`, using version `0.11.1` — consistent with the version used across other flux packages.

## Files Changed

- `packages/comment-section/package.json` — added `"@coasys/ad4m": "0.11.1"` to dependencies
- `pnpm-lock.yaml` — updated lockfile to reflect the new dependency
- `packages/ui/meta.json` — updated after rebuild

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies in the comment section package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->