### PR TITLE
fix: revert @coasys/ad4m override from link: back to registry version

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
       "@coasys/flux-utils": "workspace:*",
       "@coasys/flux-vue": "workspace:*",
       "@coasys/flux-webrtc": "workspace:*",
-      "@coasys/ad4m": "link:../ad4m/core",
+      "@coasys/ad4m": "0.13.0-test-4",
       "@coasys/ad4m-connect": "0.13.0-test-4",
       "@coasys/ad4m-vue-hooks": "0.13.0-test-4",
       "@coasys/ad4m-react-hooks": "0.13.0-test-4"


### PR DESCRIPTION
# Fix: Revert `@coasys/ad4m` override from `link:` back to registry version

## Problem

Commit `a84db4aa` accidentally re-introduced `"@coasys/ad4m": "link:../ad4m/core"` into the root `package.json` pnpm overrides. This breaks Netlify CI for any PR branch that doesn't have a matching branch in the `coasys/ad4m` repo.

When no matching ad4m branch exists, the build script (`scripts/build-with-ad4m-link.sh`) restores `package.json` from `origin/dev` and uses published npm packages. But with the `link:` override present, pnpm cannot resolve `@coasys/ad4m` on Netlify (where `../ad4m/core` doesn't exist), causing builds to fail with:

> `Rollup failed to resolve import "@coasys/ad4m"`

This was previously fixed in `53ca6f14` with the explicit note: *"CI has no ../ad4m directory — link: overrides should not be committed"*.

## Fix

Revert the override back to the pinned registry version:

```diff
- "@coasys/ad4m": "link:../ad4m/core",
+ "@coasys/ad4m": "0.13.0-test-4",
```

The build script already handles swapping this to a local `file:` reference when a matching ad4m branch is found — the `link:` override in `package.json` is never needed.

## Files Changed

- `package.json` — one-line revert of the ad4m override
