### PR TITLE
refactor: write literal property values directly + decode both old and new shapes

### DIFF
--- a/ADAM_MODEL_MIGRATION.md
+++ b/ADAM_MODEL_MIGRATION.md
@@ -19,7 +19,8 @@ branch, then migrate Flux against the updated packages.
 | `@ReadOnly({ through, getter })`           | `@Property({ through, readOnly: true, getter })`           |
 | `writable: true`                           | remove (writable is now the default)                       |
 | `writable: false`                          | `readOnly: true`                                           |
-| `resolveLanguage: 'literal'`               | remove (now the implicit default)                          |
+| `resolveLanguage: 'literal'`               | remove entirely (`resolveLiteral: true` is now the default) |
+| `resolveLanguage: <languageAddress>`       | `resolveLiteral: false` (non-literal expression languages)  |
 | `entry.baseExpression`                     | `entry.id`                                                 |
 | `new Model(perspective, id, source)`       | `new Model(perspective, id)` (source arg removed)          |
 | `makeRandomPrologAtom(n)`                  | `makeRandomId(n)`                                          |

--- a/app/src/views/main/profile/ProfileView.vue
+++ b/app/src/views/main/profile/ProfileView.vue
@@ -120,7 +120,8 @@
 import { useAppStore, useModalStore, useThemeStore, useUiStore } from '@/stores';
 import { getCachedAgentProfile } from '@/utils/userProfileCache';
 import Modals from '@/views/main/profile/modals/Modals.vue';
-import { EntanglementProof, LinkExpression, Literal } from '@coasys/ad4m';
+import { EntanglementProof, LinkExpression } from '@coasys/ad4m';
+import { unwrapLiteralValue } from '@coasys/flux-utils';
 import { getAgentWebLinks } from '@coasys/flux-api';
 import { Profile } from '@coasys/flux-types';
 import { computed, onBeforeMount, ref, watch } from 'vue';
@@ -230,7 +231,7 @@ async function removeProof(proof: EntanglementProof) {
         return (
           l.data.predicate === 'ad4m://entanglement_proof' &&
           l.data.target.startsWith('literal:') &&
-          Literal.fromUrl(l.data.target).get().data.deviceKey === proof.deviceKey
+          unwrapLiteralValue(l.data.target)?.deviceKey === proof.deviceKey
         );
       }) || [];
 

--- a/docs/src/create-flux-plugin/basics/subjects.md
+++ b/docs/src/create-flux-plugin/basics/subjects.md
@@ -48,21 +48,18 @@ export default class Todo {
   @Property({
     through: 'rdf://title',
     writable: true,
-    resolveLanguage: 'literal',
   })
   title: string;
 
   @Property({
     through: 'rdf://description',
     writable: true,
-    resolveLanguage: 'literal',
   })
   desc: string;
 
   @Property({
     through: 'rdf://status',
     writable: true,
-    resolveLanguage: 'literal',
   })
   done: boolean;
 }

--- a/packages/api/src/getAgentWebLinks.ts
+++ b/packages/api/src/getAgentWebLinks.ts
@@ -1,5 +1,5 @@
-import { Ad4mClient, LinkExpression, Literal } from '@coasys/ad4m';
-import { mapLiteralLinks } from '@coasys/flux-utils';
+import { Ad4mClient, LinkExpression } from '@coasys/ad4m';
+import { mapLiteralLinks, unwrapLiteralValue } from '@coasys/flux-utils';
 import { profile } from '@coasys/flux-constants';
 import { WebLink } from '@coasys/flux-types';
 
@@ -26,7 +26,7 @@ export default async function getAgentWebLinks(did: string, client: Ad4mClient):
 
     return {
       ...ogData,
-      url: Literal.fromUrl(parentLink.data.target).get().data,
+      url: unwrapLiteralValue(parentLink.data.target) ?? parentLink.data.target,
       id: parentLink.data.target,
     } as WebLink;
   });

--- a/packages/api/src/utils/parseLit.test.ts
+++ b/packages/api/src/utils/parseLit.test.ts
@@ -27,10 +27,12 @@ describe('parseLit', () => {
     expect(parseLit(url)).toBe('hello world');
   });
 
-  it('extracts .data from JSON literal objects', () => {
+  it('JSON-stringifies objects that carry a data field', () => {
+    // Envelope semantics live in `unwrapLiteralValue` (flux-utils); parseLit
+    // returns the JSON shape verbatim and leaves shape decisions to callers.
     const { Literal } = require('@coasys/ad4m');
     const url = Literal.from({ data: 'extracted' }).toUrl();
-    expect(parseLit(url)).toBe('extracted');
+    expect(parseLit(url)).toBe(JSON.stringify({ data: 'extracted' }));
   });
 
   it('JSON-stringifies objects without .data field', () => {

--- a/packages/api/src/utils/unwrapLiteralValue.test.ts
+++ b/packages/api/src/utils/unwrapLiteralValue.test.ts
@@ -1,0 +1,47 @@
+import { Literal } from '@coasys/ad4m';
+import { unwrapLiteralValue } from '@coasys/flux-utils';
+
+describe('unwrapLiteralValue', () => {
+  it('returns undefined for nullish or empty input', () => {
+    expect(unwrapLiteralValue(undefined)).toBeUndefined();
+    expect(unwrapLiteralValue(null)).toBeUndefined();
+    expect(unwrapLiteralValue('')).toBeUndefined();
+  });
+
+  it('returns undefined for non-literal URIs', () => {
+    expect(unwrapLiteralValue('flux://has_channel')).toBeUndefined();
+    expect(unwrapLiteralValue('did:key:z6MkExample')).toBeUndefined();
+  });
+
+  it('decodes plain literal:string: values', () => {
+    const url = Literal.from('hello').toUrl();
+    expect(unwrapLiteralValue(url)).toBe('hello');
+  });
+
+  it('decodes plain literal:number: values', () => {
+    const url = Literal.from(42).toUrl();
+    expect(unwrapLiteralValue(url)).toBe(42);
+  });
+
+  it('returns plain JSON objects as-is', () => {
+    const url = Literal.from({ foo: 'bar' }).toUrl();
+    expect(unwrapLiteralValue(url)).toEqual({ foo: 'bar' });
+  });
+
+  it('unwraps signed-envelope literal:json: targets to their inner data', () => {
+    const envelope = {
+      author: 'did:key:z6MkExample',
+      timestamp: '2024-01-01T00:00:00Z',
+      data: 'wrapped value',
+      proof: { key: '#z6MkExample', signature: 'sig', valid: true },
+    };
+    const url = Literal.from(envelope).toUrl();
+    expect(unwrapLiteralValue(url)).toBe('wrapped value');
+  });
+
+  it('leaves non-envelope JSON containing a data field alone', () => {
+    // A user payload that happens to have `data` but no envelope siblings.
+    const url = Literal.from({ data: 'payload', kind: 'other' }).toUrl();
+    expect(unwrapLiteralValue(url)).toEqual({ data: 'payload', kind: 'other' });
+  });
+});

--- a/packages/utils/src/createNeighbourhoodMeta.ts
+++ b/packages/utils/src/createNeighbourhoodMeta.ts
@@ -1,4 +1,4 @@
-import { Ad4mClient, Link, LinkExpression } from '@coasys/ad4m';
+import { Ad4mClient, Link, LinkExpression, Literal } from '@coasys/ad4m';
 import { community } from '@coasys/flux-constants';
 const { CREATOR, DESCRIPTION, NAME, SELF, CREATED_AT } = community;
 
@@ -11,15 +11,17 @@ export async function createNeighbourhoodMeta(
   //Create the perspective to hold our meta
   const perspective = await client.perspective.add(`${name}-meta`);
 
-  const nameExpression = await client.expression.create(name, 'literal');
-  const createdAtExpression = await client.expression.create(new Date().toISOString(), 'literal');
+  // Property values are encoded as deterministic plain literal URIs client-side;
+  // the link reifier carries the canonical author/timestamp/proof for the write.
+  const nameTarget = Literal.from(name).toUrl();
+  const createdAtTarget = Literal.from(new Date().toISOString()).toUrl();
 
   //Create the links we want on meta
   const expressionLinks = [] as Link[];
   expressionLinks.push(
     new Link({
       source: SELF,
-      target: nameExpression,
+      target: nameTarget,
       predicate: NAME,
     }),
   );
@@ -35,17 +37,17 @@ export async function createNeighbourhoodMeta(
   expressionLinks.push(
     new Link({
       source: SELF,
-      target: createdAtExpression,
+      target: createdAtTarget,
       predicate: CREATED_AT,
     }),
   );
 
   if (description != '') {
-    const descriptionExpression = await client.expression.create(description, 'literal');
+    const descriptionTarget = Literal.from(description).toUrl();
     expressionLinks.push(
       new Link({
         source: SELF,
-        target: descriptionExpression,
+        target: descriptionTarget,
         predicate: DESCRIPTION,
       }),
     );

--- a/packages/utils/src/getNeighbourhoodMeta.ts
+++ b/packages/utils/src/getNeighbourhoodMeta.ts
@@ -1,6 +1,7 @@
-import { Ad4mClient, LinkExpression, Literal } from '@coasys/ad4m';
+import { Ad4mClient, LinkExpression } from '@coasys/ad4m';
 import { NeighbourhoodMetaData } from '@coasys/flux-types';
 import { community } from '@coasys/flux-constants';
+import { unwrapLiteralValue } from './unwrapLiteralValue';
 
 const { DESCRIPTION, NAME, CREATOR, CREATED_AT } = community;
 
@@ -9,10 +10,12 @@ export function getMetaFromLinks(links: LinkExpression[]): NeighbourhoodMetaData
     (acc, link) => {
       const { predicate, target } = link.data;
       return {
-        name: predicate === NAME ? Literal.fromUrl(target).get().data : acc.name,
-        description: predicate === DESCRIPTION ? Literal.fromUrl(target).get().data : acc.description,
+        name: predicate === NAME ? unwrapLiteralValue(target) ?? acc.name : acc.name,
+        description: predicate === DESCRIPTION ? unwrapLiteralValue(target) ?? acc.description : acc.description,
         author: predicate === CREATOR ? target : acc.author,
-        timestamp: predicate === CREATED_AT ? (target.startsWith('literal:') ? Literal.fromUrl(target).get().data : target) : acc.timestamp,
+        timestamp: predicate === CREATED_AT
+          ? (target.startsWith('literal:') ? unwrapLiteralValue(target) ?? acc.timestamp : target)
+          : acc.timestamp,
       };
     },
     {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -17,3 +17,4 @@ export * from './scrollHelpers';
 export * from './sleep';
 export * from './synergy';
 export * from './throttle';
+export * from './unwrapLiteralValue';

--- a/packages/utils/src/linkHelpers.ts
+++ b/packages/utils/src/linkHelpers.ts
@@ -2,6 +2,7 @@ import { Ad4mClient, Link, LinkInput } from '@coasys/ad4m';
 import { LinkExpression, Literal } from '@coasys/ad4m';
 import { community } from '@coasys/flux-constants';
 import { EntryType, PropertyMap, PredicateMap } from '@coasys/flux-types';
+import { unwrapLiteralValue } from './unwrapLiteralValue';
 
 const { CARD_HIDDEN, CHANNEL, MEMBER, REACTION, EDITED_TO, HAS_REPLY, ZOME } = community;
 
@@ -32,21 +33,10 @@ export function mapLiteralLinks(links: LinkExpression[] | undefined, map: Proper
     const link = links?.find((link) => link.data.predicate === predicate);
 
     if (link) {
-      let data;
-
-      if (link.data.target.startsWith('literal:string:')) {
-        data = Literal.fromUrl(link.data.target).get();
-      } else if (link.data.target.startsWith('literal:number:')) {
-        data = Literal.fromUrl(link.data.target).get();
-      } else if (link.data.target.startsWith('literal:json:')) {
-        data = Literal.fromUrl(link.data.target).get().data;
-      } else {
-        data = link.data.target;
-      }
-
+      const decoded = unwrapLiteralValue(link.data.target);
       return {
         ...acc,
-        [key]: data,
+        [key]: decoded ?? link.data.target,
       };
     }
     return acc;

--- a/packages/utils/src/linkHelpers.ts
+++ b/packages/utils/src/linkHelpers.ts
@@ -1,5 +1,4 @@
-import { Ad4mClient, Link, LinkInput } from '@coasys/ad4m';
-import { LinkExpression } from '@coasys/ad4m';
+import { Ad4mClient, Link, LinkInput, LinkExpression, Literal } from '@coasys/ad4m';
 import { community } from '@coasys/flux-constants';
 import { EntryType, PropertyMap, PredicateMap } from '@coasys/flux-types';
 import { unwrapLiteralValue } from './unwrapLiteralValue';
@@ -43,20 +42,15 @@ export function mapLiteralLinks(links: LinkExpression[] | undefined, map: Proper
   }, {});
 }
 
-export async function createLiteralLinks(client: Ad4mClient, source: string, map: PredicateMap) {
-  const targets = Object.keys(map);
-
-  const promises = targets
-    .filter((predicate: any) => {
-      return typeof map[predicate] === 'string';
-    })
-    .map(async (predicate: string) => {
-      const message = map[predicate];
-      const exp = await client.expression.create(message, 'literal');
-      return new Link({ source, predicate, target: exp });
+export async function createLiteralLinks(_client: Ad4mClient, source: string, map: PredicateMap) {
+  // Values land as deterministic `literal:string:` targets — the link reifier
+  // carries the author/timestamp/proof for the write itself.
+  return Object.keys(map)
+    .filter((predicate) => typeof map[predicate] === 'string')
+    .map((predicate) => {
+      const target = Literal.from(map[predicate] as string).toUrl();
+      return new Link({ source, predicate, target });
     });
-
-  return Promise.all(promises);
 }
 
 //function to create links from a map of predicates to targets
@@ -83,15 +77,19 @@ export async function createLiteralObject(
   client: Ad4mClient,
   { parent, children }: { parent: LinkInput; children: PredicateMap },
 ) {
-  const expUrl = await client.expression.create(parent.target, 'literal');
+  // The deterministic literal URL doubles as a stable entity identity for
+  // the children to attach to — two calls with the same `parent.target`
+  // resolve to the same parent IRI, which is the intended semantics for
+  // value-keyed entities like web links.
+  const parentTarget = Literal.from(parent.target).toUrl();
 
   const parentLink = new Link({
     source: parent.source,
     predicate: parent.predicate,
-    target: expUrl,
+    target: parentTarget,
   });
 
-  const childrenLinks = await createLiteralLinks(client, expUrl, children);
+  const childrenLinks = await createLiteralLinks(client, parentTarget, children);
 
   return [parentLink, ...childrenLinks];
 }

--- a/packages/utils/src/linkHelpers.ts
+++ b/packages/utils/src/linkHelpers.ts
@@ -1,5 +1,5 @@
 import { Ad4mClient, Link, LinkInput } from '@coasys/ad4m';
-import { LinkExpression, Literal } from '@coasys/ad4m';
+import { LinkExpression } from '@coasys/ad4m';
 import { community } from '@coasys/flux-constants';
 import { EntryType, PropertyMap, PredicateMap } from '@coasys/flux-types';
 import { unwrapLiteralValue } from './unwrapLiteralValue';

--- a/packages/utils/src/prologHelpers.ts
+++ b/packages/utils/src/prologHelpers.ts
@@ -1,5 +1,6 @@
 import { EntryType, ModelProperty, Entry } from '@coasys/flux-types';
 import { Ad4mClient, Literal } from '@coasys/ad4m';
+import { unwrapLiteralValue } from './unwrapLiteralValue';
 
 /** Entry with dynamically-resolved model properties from prolog queries */
 type ResolvedEntry = Entry & Record<string, unknown>;
@@ -131,7 +132,7 @@ export async function resolveEntryWithLatestProperties(
 
     async function resolveExp(url: string) {
       return url.startsWith('literal:')
-        ? Literal.fromUrl(url).get().data
+        ? unwrapLiteralValue(url)
         : (await client.expression.get(url)).data.replace(/['"]+/g, '');
     }
 

--- a/packages/utils/src/prologHelpers.ts
+++ b/packages/utils/src/prologHelpers.ts
@@ -1,5 +1,5 @@
 import { EntryType, ModelProperty, Entry } from '@coasys/flux-types';
-import { Ad4mClient, Literal } from '@coasys/ad4m';
+import { Ad4mClient } from '@coasys/ad4m';
 import { unwrapLiteralValue } from './unwrapLiteralValue';
 
 /** Entry with dynamically-resolved model properties from prolog queries */

--- a/packages/utils/src/unwrapLiteralValue.ts
+++ b/packages/utils/src/unwrapLiteralValue.ts
@@ -1,0 +1,34 @@
+import { Literal } from '@coasys/ad4m';
+
+/**
+ * Decode a `literal:` link target into its underlying value.
+ *
+ * Newer executor builds store property literals as plain `literal:string:`,
+ * `:number:`, `:boolean:`, or `:json:` targets, where `Literal.fromUrl().get()`
+ * returns the underlying value directly. Older builds — and any value created
+ * via `expression.create(value, "literal")` — wrap the value in a signed
+ * envelope `{ author, timestamp, data, proof }`; for those, the actual value
+ * is on `.data`. This helper covers both shapes.
+ *
+ * Returns `undefined` when the target is not a literal URL or cannot be
+ * decoded; callers can substitute the raw target string if they prefer.
+ */
+export function unwrapLiteralValue(target: string | undefined | null): any {
+  if (target === undefined || target === null || target === '') return undefined;
+  let parsed: any;
+  try {
+    parsed = Literal.fromUrl(target).get();
+  } catch {
+    return undefined;
+  }
+  if (
+    parsed &&
+    typeof parsed === 'object' &&
+    'data' in parsed &&
+    'author' in parsed &&
+    'proof' in parsed
+  ) {
+    return parsed.data;
+  }
+  return parsed;
+}

--- a/views/graph-view/src/components/CommunityGraph.tsx
+++ b/views/graph-view/src/components/CommunityGraph.tsx
@@ -1,5 +1,6 @@
 import ForceGraph3D, { ForceGraph3DInstance } from '3d-force-graph';
-import { Literal, PerspectiveProxy } from '@coasys/ad4m';
+import { PerspectiveProxy } from '@coasys/ad4m';
+import { unwrapLiteralValue } from '@coasys/flux-utils';
 import { useEffect, useRef, useState } from 'preact/hooks';
 import SpriteText from 'three-spritetext';
 import styles from '../App.module.css';
@@ -127,7 +128,7 @@ export default function CommunityOverview({ perspective, source }: { perspective
       graph.current = ForceGraph3D()(graphEl.current)
         .graphData({ nodes, links })
         .nodeLabel((node: any) => {
-          return node.id.startsWith('literal://') ? Literal.fromUrl(node.id).get().data : node.id;
+          return node.id.startsWith('literal:') ? unwrapLiteralValue(node.id) ?? node.id : node.id;
         })
         .backgroundColor('rgba(0,0,0,0)')
         .nodeAutoColorBy('group')

--- a/views/kanban-view/src/components/Board/TaskModel.ts
+++ b/views/kanban-view/src/components/Board/TaskModel.ts
@@ -4,7 +4,6 @@ import { Ad4mModel, Model, Property, HasMany } from '@coasys/ad4m';
 export class Task extends Ad4mModel {
   @Property({
     through: 'rdf://name',
-    resolveLanguage: 'literal',
     required: true,
     writable: true,
     initial: 'New task',

--- a/views/table-view/src/components/NewClass/NewClass.tsx
+++ b/views/table-view/src/components/NewClass/NewClass.tsx
@@ -247,8 +247,8 @@ async function buildSHACLShape(
       writable: true,
     };
 
-    if (language) {
-      propShape.resolveLanguage = language;
+    if (language && language !== 'literal') {
+      propShape.resolveLiteral = false;
     }
 
     if (options.length > 0) {


### PR DESCRIPTION
## Summary

Companion to [coasys/ad4m#837](https://github.com/coasys/ad4m/pull/837). After that PR lands, the ad4m executor stops embedding signed-expression envelopes (`{author, timestamp, data, proof}`) in link targets when properties are written through the literal language — per-link author/timestamp/proof lives only on the RDF reifier going forward. This PR brings flux into line on both sides of that contract: the **write** helpers that put the envelope into the target in the first place, and the **read** sites that pulled values out of the envelope shape via `.get().data`.

## Writes — stop embedding provenance in targets

Five flux call sites previously routed property values through `client.expression.create(value, 'literal')`. The executor's literal language signs the value into a `literal:json:<envelope>` URL, so the target carried `{author, timestamp, data, proof}` duplicating provenance the reifier already holds. After this PR every property target is encoded client-side as a deterministic plain `literal:string:` / `:number:` / `:boolean:` / `:json:` URL via `Literal.from(value).toUrl()`. No round-trip to the executor, no embedded provenance, no envelope.

| File | Sites |
|---|---|
| `packages/utils/src/createNeighbourhoodMeta.ts` | neighbourhood `name`, `createdAt`, `description` |
| `packages/utils/src/linkHelpers.ts` (`createLiteralLinks`) | generic property-link helper used by `createProfile`, `updateProfile` |
| `packages/utils/src/linkHelpers.ts` (`createLiteralObject`) | parent + children helper used by `createAgentWebLink` |

`createLiteralObject` gains a useful side effect: the deterministic parent URL doubles as a stable entity identity, so two calls with the same `parent.target` value resolve to the same IRI — which is what callers like `createAgentWebLink` actually want (same URL → same WebLink entity).

`grep -rn "expression\.create\([^)]*['\"]literal['\"]\)"` against `packages/` returns no hits after this PR. The only remaining `expression.create("…", "literal")` callers across the ecosystem are dapp entanglement proofs and agent expressions in the ad4m repo, both of which intentionally produce addressable signed expressions (a separate concern from link-property storage).

## Reads — handle both old and new target shapes

New `unwrapLiteralValue(target)` helper in `@coasys/flux-utils` that decodes `literal:` URLs and returns the inner value:
- Plain literal → returns the decoded value directly.
- Signed-expression envelope (legacy data on disk before the ad4m migration runs, plus any explicit `expression.create(value, "literal")` URL that callers feed in) → returns the inner `.data`.
- Anything else (non-literal URL, undecodable) → returns `undefined`; call sites substitute the raw target.

Updated four reader sites that previously assumed the envelope shape:

| File | Was |
|---|---|
| `packages/utils/src/linkHelpers.ts` (`mapLiteralLinks`) | three-prong startsWith dispatch with `.get().data` on the json: branch |
| `packages/utils/src/getNeighbourhoodMeta.ts` (`getMetaFromLinks`) | `.get().data` on NAME / DESCRIPTION / CREATED_AT predicates |
| `packages/utils/src/prologHelpers.ts` (`resolveExp` inside model property resolution) | `.get().data` on literal: URLs |
| `packages/api/src/getAgentWebLinks.ts` | `.get().data` on weblink parent target |

Plus `packages/api/src/utils/parseLit.test.ts` flipped from asserting `.data` extraction to asserting `JSON.stringify(obj)` to match `parseLit`'s new behaviour in ad4m#837 (envelope semantics live in `unwrapLiteralValue` now, not in `parseLit`).

## Test plan

- [x] `pnpm exec vitest run packages/api/src/utils/` — `unwrapLiteralValue` (7/7) + `parseLit` (6/7 locally against the published ad4m, 7/7 expected in CI against the linked branch)
- [x] `pnpm exec tsc --noEmit -p packages/utils/tsconfig.json` clean for changed files
- [x] `pnpm exec tsc --noEmit -p packages/api/tsconfig.json` clean for changed files
- [ ] Full CI green on this PR (resolves the parseLit assertion via the same-name ad4m branch)
- [ ] Manual smoke: create a community, verify name/description round-trip through `createNeighbourhoodMeta` + `getMetaFromLinks`
- [ ] Manual smoke: create a WebLink, verify two calls with the same URL produce one entity (deterministic identity check)

## Cross-repo coupling

Flux CI resolves the same-name `refactor/literal-channel-v-separation` branch of `@coasys/ad4m` and tests against that build, not the currently-published version. The two PRs ship as one logical change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored literal value processing throughout the codebase for improved consistency and maintainability.
  * Updated link and metadata derivation to use deterministic URL generation.
  * Introduced a centralized utility for decoding literal values across components.

* **Tests**
  * Added comprehensive test suite for literal value unwrapping functionality.
  * Updated existing tests to reflect changes in literal object handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->