### PR TITLE
feat(api): thread AbortSignal through querySparql wrappers

### DIFF
--- a/packages/api/src/channel/channel.test.ts
+++ b/packages/api/src/channel/channel.test.ts
@@ -239,6 +239,33 @@ describe('Channel.allItems()', () => {
     expect(typed.timestamp).toBe('2026-04-20T10:02:00.000Z');
     expect(voice.timestamp < typed.timestamp).toBe(true);
   });
+
+  // ── AbortSignal handling ───────────────────────────────────────────
+  //
+  // Two contracts the wrapper must honour:
+  //   1. Forward the `signal` to perspective.querySparql so the executor
+  //      receives `request.cancel`.
+  //   2. Re-throw AbortError instead of swallowing it (other errors are
+  //      swallowed for graceful degradation).  Without this, callers
+  //      can't distinguish cancellation from real failures.
+
+  it('forwards the AbortSignal to perspective.querySparql', async () => {
+    const perspective = createMockPerspective(async () => []);
+    const channel = new Channel(perspective as any, 'channel-1');
+    const controller = new AbortController();
+    await channel.allItems({ signal: controller.signal });
+    expect(perspective.querySparql).toHaveBeenCalledWith(
+      expect.any(String),
+      { signal: controller.signal },
+    );
+  });
+
+  it('re-throws AbortError instead of swallowing it', async () => {
+    const perspective = createMockPerspective();
+    perspective.querySparql.mockRejectedValueOnce(new DOMException('Aborted', 'AbortError'));
+    const channel = new Channel(perspective as any, 'channel-1');
+    await expect(channel.allItems()).rejects.toMatchObject({ name: 'AbortError' });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/channel/index.ts
+++ b/packages/api/src/channel/index.ts
@@ -1,4 +1,5 @@
 import { Ad4mModel, HasMany, HasManyMethods, Flag, Literal, LinkQuery, Model, Property, PerspectiveProxy, parseLit, parseSparqlCount, CountBinding } from '@coasys/ad4m';
+import type { AbortOptions } from '../shared/abort';
 import { community } from '@coasys/flux-constants';
 import { EntryType } from '@coasys/flux-types';
 import { SynergyGroup, SynergyItem, ItemType, icons } from '@coasys/flux-utils';
@@ -95,7 +96,7 @@ export class Channel extends Ad4mModel {
   @HasMany(() => Post)
   posts: Post[] = [];
 
-  async allItems(): Promise<SynergyItem[]> {
+  async allItems(options?: AbortOptions): Promise<SynergyItem[]> {
     // Get all items (messages, posts, tasks) in the channel
     try {
       const sparqlQuery = `
@@ -115,7 +116,7 @@ export class Channel extends Ad4mModel {
         ORDER BY ?timestamp
       `;
 
-      const sparqlResult = await this.perspective.querySparql<ChannelItemBinding[]>(sparqlQuery);
+      const sparqlResult = await this.perspective.querySparql<ChannelItemBinding[]>(sparqlQuery, options);
 
       const mapped = (sparqlResult || []).map((binding) => {
         let text = '';
@@ -145,12 +146,14 @@ export class Channel extends Ad4mModel {
       // Re-sort by effective timestamp since transcriptStart may differ from link timestamp
       return mapped.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
     } catch (error) {
+      // Re-throw AbortError so callers can distinguish cancellation from real failures
+      if (error instanceof DOMException && error.name === 'AbortError') throw error;
       console.error('Error getting all channel items:', error);
       return [];
     }
   }
 
-  async unprocessedItems(): Promise<SynergyItem[]> {
+  async unprocessedItems(options?: AbortOptions): Promise<SynergyItem[]> {
     // Get all unprocessed items in the channel using set-difference approach
     // instead of FILTER NOT EXISTS (which is O(N²) in Oxigraph)
     try {
@@ -182,8 +185,8 @@ export class Channel extends Ad4mModel {
       // an item to appear in allItems but not processedSet (or vice-versa).
       // The final VALUES query re-verifies channel membership to mitigate this.
       const [allItemsResult, processedResult] = await Promise.all([
-        this.perspective.querySparql<IdBinding[]>(allItemsQuery),
-        this.perspective.querySparql<IdBinding[]>(processedQuery),
+        this.perspective.querySparql<IdBinding[]>(allItemsQuery, options),
+        this.perspective.querySparql<IdBinding[]>(processedQuery, options),
       ]);
 
       const processedSet = new Set((processedResult || []).map((r) => r.id));
@@ -213,7 +216,7 @@ export class Channel extends Ad4mModel {
         ORDER BY ?timestamp
       `;
 
-      const sparqlResult = await this.perspective.querySparql<ChannelItemBinding[]>(dataQuery);
+      const sparqlResult = await this.perspective.querySparql<ChannelItemBinding[]>(dataQuery, options);
 
       // Deduplicate by id
       const itemMap = new Map<string, ChannelItemBinding>();
@@ -251,12 +254,13 @@ export class Channel extends Ad4mModel {
       // Re-sort by effective timestamp since transcriptStart may differ from link timestamp
       return mapped.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
     } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') throw error;
       console.error('Error getting channel items:', error);
       return [];
     }
   }
 
-  async totalItemCount(): Promise<number> {
+  async totalItemCount(options?: AbortOptions): Promise<number> {
     // Find the total number of items in the channel
     try {
       // SPARQL migration
@@ -268,9 +272,10 @@ export class Channel extends Ad4mModel {
         }
       `;
 
-      const sparqlResult = await this.perspective.querySparql<CountBinding[]>(sparqlQuery);
+      const sparqlResult = await this.perspective.querySparql<CountBinding[]>(sparqlQuery, options);
       return parseSparqlCount(sparqlResult);
     } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') throw error;
       console.error('Error getting total item count:', error);
       return 0;
     }
@@ -289,6 +294,7 @@ export class Channel extends Ad4mModel {
   static async recentConversations(
     perspective: PerspectiveProxy,
     limit: number = 20,
+    options?: AbortOptions,
   ): Promise<{ channelId: string; conversationId?: string; lastActivity?: string }[]> {
     // Step 1: Find conversation channels + their conversation child (fast, no reifier joins)
     const sparql = `
@@ -303,7 +309,7 @@ export class Channel extends Ad4mModel {
     `;
 
     try {
-      const results = await perspective.querySparql<RecentConversationBinding[]>(sparql);
+      const results = await perspective.querySparql<RecentConversationBinding[]>(sparql, options);
 
       // Filter to only conversation channels and dedup
       const channelMap = new Map<string, { channelId: string; conversationId?: string; lastActivity?: string }>();
@@ -326,6 +332,7 @@ export class Channel extends Ad4mModel {
         Array.from(channelMap.entries()).map(async ([channelId, entry]) => {
           const links = await perspective.get(
             new LinkQuery({ source: channelId, predicate: 'ad4m://has_child' }),
+            options,
           );
           // Find the most recent link timestamp
           let latest = '';
@@ -342,6 +349,7 @@ export class Channel extends Ad4mModel {
         .slice(0, limit);
       return sorted;
     } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') throw error;
       console.error('Error in Channel.recentConversations():', error);
       return [];
     }
@@ -353,6 +361,7 @@ export class Channel extends Ad4mModel {
    */
   static async pinnedConversations(
     perspective: PerspectiveProxy,
+    options?: AbortOptions,
   ): Promise<{ channelId: string; conversationId?: string }[]> {
     const sparql = `
       SELECT ?channelId ?conversationId WHERE {
@@ -367,7 +376,7 @@ export class Channel extends Ad4mModel {
     `;
 
     try {
-      const results = await perspective.querySparql<PinnedConversationBinding[]>(sparql);
+      const results = await perspective.querySparql<PinnedConversationBinding[]>(sparql, options);
       // Deduplicate by channelId
       const seen = new Map<string, { channelId: string; conversationId?: string }>();
       for (const r of results || []) {
@@ -380,6 +389,7 @@ export class Channel extends Ad4mModel {
       }
       return Array.from(seen.values());
     } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') throw error;
       console.error('Error in Channel.pinnedConversations():', error);
       return [];
     }

--- a/packages/api/src/conversation-subgroup/index.ts
+++ b/packages/api/src/conversation-subgroup/index.ts
@@ -1,4 +1,5 @@
 import { Model, Ad4mModel, Flag, HasMany, Property, Literal, parseLit } from '@coasys/ad4m';
+import type { AbortOptions } from '../shared/abort';
 import Topic, { TopicWithRelevance } from '../topic';
 import SemanticRelationship from '../semantic-relationship';
 import { SynergyTopic, SynergyItem, ItemType, icons } from '@coasys/flux-utils';
@@ -46,7 +47,7 @@ export default class ConversationSubgroup extends Ad4mModel {
   @HasMany({ through: FLUX_PARTICIPANT })
   participants: string[] = [];
 
-  async stats(): Promise<{ totalItems: number; participants: string[] }> {
+  async stats(options?: AbortOptions): Promise<{ totalItems: number; participants: string[] }> {
     // find the total item count and the dids of participants in the subgroup
     try {
       // SPARQL migration
@@ -66,20 +67,21 @@ export default class ConversationSubgroup extends Ad4mModel {
       `;
 
       const [itemsResult, participantsResult] = await Promise.all([
-        this.perspective.querySparql<ItemIdBinding[]>(itemsQuery),
-        this.perspective.querySparql<DidBinding[]>(participantsQuery),
+        this.perspective.querySparql<ItemIdBinding[]>(itemsQuery, options),
+        this.perspective.querySparql<DidBinding[]>(participantsQuery, options),
       ]);
 
       const totalItems = itemsResult?.length || 0;
       const participants = (participantsResult || []).map((r) => r.did).filter(Boolean);
       return { totalItems, participants };
     } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') throw error;
       console.error('Error getting subgroup stats:', error);
       return { totalItems: 0, participants: [] };
     }
   }
 
-  async topics(): Promise<SynergyTopic[]> {
+  async topics(options?: AbortOptions): Promise<SynergyTopic[]> {
     // find the subgroups topics
     try {
       // SPARQL migration
@@ -93,7 +95,7 @@ export default class ConversationSubgroup extends Ad4mModel {
         }
       `;
 
-      const sparqlResult = await this.perspective.querySparql<TopicBinding[]>(sparqlQuery);
+      const sparqlResult = await this.perspective.querySparql<TopicBinding[]>(sparqlQuery, options);
 
       // Deduplicate by topicBase
       const uniqueTopics = new Map<string, { topicBase: string; topicName: string }>();
@@ -114,12 +116,13 @@ export default class ConversationSubgroup extends Ad4mModel {
         }),
       );
     } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') throw error;
       console.error('Error getting subgroup topics:', error);
       return [];
     }
   }
 
-  async itemsData(): Promise<SynergyItem[]> {
+  async itemsData(options?: AbortOptions): Promise<SynergyItem[]> {
     // find the necissary data to render the subgroups items in timeline components
     try {
       // SPARQL migration
@@ -145,7 +148,7 @@ export default class ConversationSubgroup extends Ad4mModel {
         ORDER BY ?timestamp
       `;
 
-      const sparqlResult = await this.perspective.querySparql<SubgroupItemBinding[]>(sparqlQuery);
+      const sparqlResult = await this.perspective.querySparql<SubgroupItemBinding[]>(sparqlQuery, options);
 
       // Collect items — keep duplicate IDs so the view can detect and clean them up
       const items: SubgroupItem[] = [];
@@ -221,12 +224,13 @@ export default class ConversationSubgroup extends Ad4mModel {
         };
       });
     } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') throw error;
       console.error('Error getting subgroup items:', error);
       return [];
     }
   }
 
-  async topicsWithRelevance(): Promise<TopicWithRelevance[]> {
+  async topicsWithRelevance(options?: AbortOptions): Promise<TopicWithRelevance[]> {
     try {
       // SPARQL migration
       const sparqlQuery = `
@@ -240,7 +244,7 @@ export default class ConversationSubgroup extends Ad4mModel {
         }
       `;
 
-      const sparqlResult = await this.perspective.querySparql<TopicRelevanceBinding[]>(sparqlQuery);
+      const sparqlResult = await this.perspective.querySparql<TopicRelevanceBinding[]>(sparqlQuery, options);
 
       // Deduplicate by topicBase
       const uniqueTopics = new Map<string, { topicBase: string; topicName: string; relevance: string }>();
@@ -261,6 +265,7 @@ export default class ConversationSubgroup extends Ad4mModel {
         relevance: parseInt(relevance, 10) || 0,
       }));
     } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') throw error;
       console.error('Error getting subgroup topics with relevance:', error);
       return [];
     }

--- a/packages/api/src/conversation/index.ts
+++ b/packages/api/src/conversation/index.ts
@@ -1,6 +1,7 @@
 import { Ad4mModel, Ad4mClient, Flag, HasMany, HasManyMethods, Link, Literal, Model, Property, parseLit } from '@coasys/ad4m';
 
 import { getProfile, Topic } from '@coasys/flux-api';
+import type { AbortOptions } from '../shared/abort';
 import { ProcessingState, Profile } from '@coasys/flux-types';
 import { SynergyGroup, SynergyItem, SynergyTopic } from '@coasys/flux-utils';
 import ConversationSubgroup from '../conversation-subgroup';
@@ -53,7 +54,7 @@ export class Conversation extends Ad4mModel {
   @HasMany(() => ConversationSubgroup)
   subgroupEntities: ConversationSubgroup[] = [];
 
-  async stats(): Promise<{ totalSubgroups: number; participants: string[] }> {
+  async stats(options?: AbortOptions): Promise<{ totalSubgroups: number; participants: string[] }> {
     // find the total subgroup count and the dids of participants in the conversation
     try {
       // SPARQL migration
@@ -71,20 +72,21 @@ export class Conversation extends Ad4mModel {
       `;
 
       const [subgroupsResult, participantsResult] = await Promise.all([
-        this.perspective.querySparql<SgBinding[]>(subgroupsQuery),
-        this.perspective.querySparql<DidBinding[]>(participantsQuery),
+        this.perspective.querySparql<SgBinding[]>(subgroupsQuery, options),
+        this.perspective.querySparql<DidBinding[]>(participantsQuery, options),
       ]);
 
       const totalSubgroups = subgroupsResult?.length || 0;
       const participants = (participantsResult || []).map((r) => r.did).filter(Boolean);
       return { totalSubgroups, participants };
     } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') throw error;
       console.error('Error getting conversation stats:', error);
       return { totalSubgroups: 0, participants: [] };
     }
   }
 
-  async topics(): Promise<SynergyTopic[]> {
+  async topics(options?: AbortOptions): Promise<SynergyTopic[]> {
     // find the conversations topics (via its subgroups)
     try {
       // SPARQL migration
@@ -103,7 +105,7 @@ export class Conversation extends Ad4mModel {
         }
       `;
 
-      const sparqlResult = await this.perspective.querySparql<TopicBinding[]>(sparqlQuery);
+      const sparqlResult = await this.perspective.querySparql<TopicBinding[]>(sparqlQuery, options);
 
       // Deduplicate by topicBase
       const uniqueTopics = new Map<string, { topicBase: string; topicName: string }>();
@@ -124,20 +126,21 @@ export class Conversation extends Ad4mModel {
         }),
       );
     } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') throw error;
       console.error('Error getting conversation topics:', error);
       return [];
     }
   }
 
-  async subgroups(): Promise<ConversationSubgroup[]> {
+  async subgroups(options?: AbortOptions): Promise<ConversationSubgroup[]> {
     // find the conversations subgroup entities — use parent-scoped query
     // instead of this.get() which fetches all Conversation triples
     return ConversationSubgroup.findAll(this.perspective, {
       parent: { model: Conversation, id: this.id },
-    }) as unknown as Promise<ConversationSubgroup[]>;
+    }, options) as unknown as Promise<ConversationSubgroup[]>;
   }
 
-  async subgroupsData(): Promise<SynergyGroup[]> {
+  async subgroupsData(options?: AbortOptions): Promise<SynergyGroup[]> {
     // find the necissary data to render the conversations subgroups in timeline components (include timestamps for the first and last item in each subgroup)
     try {
       // SPARQL migration
@@ -154,7 +157,7 @@ export class Conversation extends Ad4mModel {
         ORDER BY ?timestamp
       `;
 
-      const sparqlResult = await this.perspective.querySparql<SubgroupRowBinding[]>(sparqlQuery);
+      const sparqlResult = await this.perspective.querySparql<SubgroupRowBinding[]>(sparqlQuery, options);
 
       // Deduplicate by id
       const subgroupMap = new Map<string, SubgroupRow>();
@@ -189,7 +192,7 @@ export class Conversation extends Ad4mModel {
         }
       `;
 
-      const batchResults = await this.perspective.querySparql<SubgroupTimestampBinding[]>(batchTimestampQuery);
+      const batchResults = await this.perspective.querySparql<SubgroupTimestampBinding[]>(batchTimestampQuery, options);
 
       // Group timestamps by subgroup ID
       const timestampsBySg = new Map<string, number[]>();
@@ -222,6 +225,7 @@ export class Conversation extends Ad4mModel {
       // Sort by actual content start time, not link creation time
       return subgroups.sort((a, b) => Number(a.start) - Number(b.start));
     } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') throw error;
       console.error('Error getting conversation subgroups:', error);
       return [];
     }

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -28,6 +28,7 @@ import TaskColumn from './task-column';
 import TaskBoard from './task-board';
 import updateProfile from './updateProfile';
 export * from './npmApi';
+export type { AbortOptions } from './shared/abort';
 
 export {
   App,

--- a/packages/api/src/semantic-relationship/index.ts
+++ b/packages/api/src/semantic-relationship/index.ts
@@ -1,5 +1,6 @@
 import { Model, Ad4mModel, Flag, Property } from '@coasys/ad4m';
 import { parseLit } from '../utils/parseLit';
+import type { AbortOptions } from '../shared/abort';
 import { SynergyMatch } from '@coasys/flux-utils';
 
 const TYPE_MAP: Record<string, string> = {
@@ -22,7 +23,7 @@ export default class SemanticRelationship extends Ad4mModel {
   @Property({ through: 'flux://has_relevance' })
   relevance: number; // 0 - 100
 
-  async itemEmbedding(itemId: string): Promise<number[]> {
+  async itemEmbedding(itemId: string, options?: AbortOptions): Promise<number[]> {
     try {
       const sparqlQuery = `
         SELECT ?embedding WHERE {
@@ -35,18 +36,19 @@ export default class SemanticRelationship extends Ad4mModel {
         LIMIT 1
       `;
 
-      const sparqlResult = await this.perspective.querySparql(sparqlQuery);
+      const sparqlResult = await this.perspective.querySparql(sparqlQuery, options);
       if (!sparqlResult?.[0]?.embedding) return [];
 
       const embeddingExpression = await this.perspective.getExpression(sparqlResult[0].embedding);
       return JSON.parse(embeddingExpression.data);
     } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') throw error;
       console.error('Error getting items embedding', error);
       return [];
     }
   }
 
-  async allConversationEmbeddings(): Promise<SynergyMatch[]> {
+  async allConversationEmbeddings(options?: AbortOptions): Promise<SynergyMatch[]> {
     try {
       const sparqlQuery = `
         SELECT ?itemId ?embedding ?channelId ?channelName WHERE {
@@ -62,7 +64,7 @@ export default class SemanticRelationship extends Ad4mModel {
         }
       `;
 
-      const sparqlResult = await this.perspective.querySparql(sparqlQuery);
+      const sparqlResult = await this.perspective.querySparql(sparqlQuery, options);
 
       return Promise.all(
         (sparqlResult || []).map(async (binding: any) => {
@@ -77,12 +79,13 @@ export default class SemanticRelationship extends Ad4mModel {
         }),
       );
     } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') throw error;
       console.error('Error getting all conversation embedding', error);
       return [];
     }
   }
 
-  async allSubgroupEmbeddings(): Promise<SynergyMatch[]> {
+  async allSubgroupEmbeddings(options?: AbortOptions): Promise<SynergyMatch[]> {
     try {
       const sparqlQuery = `
         SELECT ?itemId ?embedding ?channelId ?channelName WHERE {
@@ -100,7 +103,7 @@ export default class SemanticRelationship extends Ad4mModel {
         }
       `;
 
-      const sparqlResult = await this.perspective.querySparql(sparqlQuery);
+      const sparqlResult = await this.perspective.querySparql(sparqlQuery, options);
 
       return Promise.all(
         (sparqlResult || []).map(async (binding: any) => {
@@ -115,12 +118,13 @@ export default class SemanticRelationship extends Ad4mModel {
         }),
       );
     } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') throw error;
       console.error('Error getting all subgroup embedding', error);
       return [];
     }
   }
 
-  async allItemEmbeddings(): Promise<SynergyMatch[]> {
+  async allItemEmbeddings(options?: AbortOptions): Promise<SynergyMatch[]> {
     try {
       const sparqlQuery = `
         SELECT ?itemId ?type ?embedding ?channelId ?channelName WHERE {
@@ -137,7 +141,7 @@ export default class SemanticRelationship extends Ad4mModel {
         }
       `;
 
-      const sparqlResult = await this.perspective.querySparql(sparqlQuery);
+      const sparqlResult = await this.perspective.querySparql(sparqlQuery, options);
 
       const typeNameMap: Record<string, string> = {
         'flux://has_message': 'Message',
@@ -158,12 +162,13 @@ export default class SemanticRelationship extends Ad4mModel {
         }),
       );
     } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') throw error;
       console.error('Error getting all item embedding', error);
       return [];
     }
   }
 
-  async allItemEmbeddingsByType(itemType: string): Promise<SynergyMatch[]> {
+  async allItemEmbeddingsByType(itemType: string, options?: AbortOptions): Promise<SynergyMatch[]> {
     // itemType is plural like "Messages", "Posts", "Tasks"
     const singular = itemType.slice(0, -1); // "Message", "Post", "Task"
     const typeUri = TYPE_MAP[singular];
@@ -187,7 +192,7 @@ export default class SemanticRelationship extends Ad4mModel {
         }
       `;
 
-      const sparqlResult = await this.perspective.querySparql(sparqlQuery);
+      const sparqlResult = await this.perspective.querySparql(sparqlQuery, options);
 
       return Promise.all(
         (sparqlResult || []).map(async (binding: any) => {
@@ -202,6 +207,7 @@ export default class SemanticRelationship extends Ad4mModel {
         }),
       );
     } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') throw error;
       console.error('Error getting item embeddings by type', error);
       return [];
     }

--- a/packages/api/src/shared/abort.ts
+++ b/packages/api/src/shared/abort.ts
@@ -1,0 +1,26 @@
+/**
+ * Structural options bag for cancellable API calls.
+ *
+ * Public methods on the Flux API wrappers accept this so callers can pass
+ * an `AbortController.signal` and have it forwarded all the way down to
+ * the executor's `request.cancel` WebSocket message.  The shape matches
+ * ad4m's `CallOptions` structurally — we don't import from `@coasys/ad4m`
+ * to keep the SDK loosely coupled to any specific ad4m version.
+ *
+ * Example:
+ * ```typescript
+ * const controller = new AbortController();
+ * try {
+ *   const items = await channel.allItems({ signal: controller.signal });
+ * } catch (e) {
+ *   if (e instanceof DOMException && e.name === 'AbortError') {
+ *     // teardown
+ *   }
+ * }
+ * // ... later, abort the in-flight query:
+ * controller.abort();
+ * ```
+ */
+export interface AbortOptions {
+  signal?: AbortSignal;
+}

--- a/packages/api/src/topic/index.ts
+++ b/packages/api/src/topic/index.ts
@@ -1,5 +1,6 @@
 import { Model, Ad4mModel, Flag, Property } from '@coasys/ad4m';
 import { parseLit } from '../utils/parseLit';
+import type { AbortOptions } from '../shared/abort';
 import { SynergyMatch } from '@coasys/flux-utils';
 
 export class TopicWithRelevance {
@@ -16,7 +17,7 @@ export default class Topic extends Ad4mModel {
   @Property({ through: 'flux://topic' })
   topic: string;
 
-  async linkedConversations(): Promise<SynergyMatch[]> {
+  async linkedConversations(options?: AbortOptions): Promise<SynergyMatch[]> {
     try {
       const sparqlQuery = `
         SELECT ?convId ?relevance ?channelId ?channelName WHERE {
@@ -32,7 +33,7 @@ export default class Topic extends Ad4mModel {
         }
       `;
 
-      const sparqlResult = await this.perspective.querySparql(sparqlQuery);
+      const sparqlResult = await this.perspective.querySparql(sparqlQuery, options);
 
       // Deduplicate by conversation ID
       const dedupMap = new Map<string, SynergyMatch>();
@@ -50,12 +51,13 @@ export default class Topic extends Ad4mModel {
       }
       return Array.from(dedupMap.values());
     } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') throw error;
       console.error('Error getting linked conversations:', error);
       return [];
     }
   }
 
-  async linkedSubgroups(): Promise<SynergyMatch[]> {
+  async linkedSubgroups(options?: AbortOptions): Promise<SynergyMatch[]> {
     try {
       const sparqlQuery = `
         SELECT ?subgroup ?relevance ?channelId ?channelName WHERE {
@@ -71,7 +73,7 @@ export default class Topic extends Ad4mModel {
         }
       `;
 
-      const sparqlResult = await this.perspective.querySparql(sparqlQuery);
+      const sparqlResult = await this.perspective.querySparql(sparqlQuery, options);
 
       // Deduplicate by subgroup ID
       const dedupMap = new Map<string, SynergyMatch>();
@@ -89,6 +91,7 @@ export default class Topic extends Ad4mModel {
       }
       return Array.from(dedupMap.values());
     } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') throw error;
       console.error('Error getting linked subgroups:', error);
       return [];
     }


### PR DESCRIPTION
## Summary

Threads an optional `AbortController.signal` through every public API method in `packages/api/` that wraps a `querySparql` call.  Callers can now cancel long-running queries (timeline loads, embedding fetches, topic lookups) when a view unmounts or a newer query supersedes the in-flight one — the executor short-circuits the JSON reply and the wrappers re-throw the cancellation as `DOMException('Aborted', 'AbortError')` instead of swallowing it.

**Backwards compatible** — every new parameter is optional.

## Why

Long-running SPARQL queries (think `Channel.allItems` over a chatty channel, or `SemanticRelationship.allItemEmbeddings` while embeddings are still being indexed) can ship megabytes of JSON back over the WebSocket.  Without cancellation, a Synergy view that unmounts mid-fetch still pays the serialise + transit + deserialise tax, even though nothing renders the result.  Now the wrappers honour an `AbortSignal` and forward it to the executor.

Caveat: Oxigraph itself can't be interrupted mid-evaluation, so the blocking thread keeps grinding until the query returns; what's saved is the JSON serialise + WebSocket reply + client deserialise tax, which is the dominant cost for large result sets.

## Wire protocol

Built on the executor-side support shipped in [coasys/ad4m#855](https://github.com/coasys/ad4m/pull/855):

```jsonc
// client → server, when AbortController fires
{ "id": "<cancel-msg-id>",
  "type": "request.cancel",
  "params": { "targetId": "<original-request-id>" } }
// the cancelled call replies with
{ "id": "<original-request-id>",
  "error": { "code": 499, "message": "Request cancelled by client" } }
```

The `CallOptions` shape is structurally compatible with ad4m's — Flux uses a local `AbortOptions { signal?: AbortSignal }` interface (in `packages/api/src/shared/abort.ts`, re-exported from the package root) so it doesn't need an ad4m version bump to consume the new executor surface.  Anyone consuming the SDK can already pass `{ signal }` if they're running against an executor with cancellation support; against older executors the signal is harmlessly forwarded and ignored.

## Methods wired

| Wrapper | Methods |
|---|---|
| `Channel` | `allItems`, `unprocessedItems`, `totalItemCount`, `recentConversations`, `pinnedConversations` |
| `Conversation` | `stats`, `topics`, `subgroups`, `subgroupsData` |
| `ConversationSubgroup` | `stats`, `topics`, `itemsData`, `topicsWithRelevance` |
| `SemanticRelationship` | `itemEmbedding`, `allConversationEmbeddings`, `allSubgroupEmbeddings`, `allItemEmbeddings`, `allItemEmbeddingsByType` |
| `Topic` | `linkedConversations`, `linkedSubgroups` |

Each wrapper:
1. Accepts `options?: AbortOptions` as the last parameter.
2. Forwards `options` to every `perspective.querySparql<T>(query, options)` (and `perspective.get(query, options)` where applicable) inside the method body.
3. Re-throws `DOMException('Aborted', 'AbortError')` instead of swallowing it — so callers can distinguish cancellation from a real query failure.  Other errors are still logged + a sensible default returned (matches pre-existing behaviour).

`conversation/util.ts` is an internal helper called only by `removeEmbedding`; left alone to keep the diff focused on user-facing API.

## Reviewer workflow

To verify end-to-end against the companion ad4m PR, use the existing branch-aware build script:

```bash
# From the Flux checkout root:
BRANCH=feat/query-abort scripts/build-with-ad4m-link.sh
```

That script detects the branch from `BRANCH` (or CI env vars), checks whether [coasys/ad4m](https://github.com/coasys/ad4m) has a matching branch, clones it, builds ad4m/core + ad4m/connect + hooks, rewrites Flux's `pnpm.overrides` to `file:./ad4m/...`, clears all caches, and builds Flux.

The companion WE PR [coasys/we#72](https://github.com/coasys/we/pull/72) adds a developer-facing equivalent at `scripts/sync-ad4m-branch.sh` with explicit `--ad4m` and `--branch` flags for local dev outside CI.

## Test plan

- [x] `Channel.allItems` forwards the signal to `perspective.querySparql`.
- [x] `Channel.allItems` re-throws `DOMException('Aborted', 'AbortError')`.
- [x] All existing wrapper tests still pass (114/114 in `packages/api` vitest suite).
- [ ] Manual: hit a slow Synergy channel, navigate away mid-load, confirm the in-flight `request.cancel` is sent (DevTools → Network → WS frames) — easiest via `BRANCH=feat/query-abort scripts/build-with-ad4m-link.sh` to pick up the companion executor support.
- [ ] CI green.

## Coordination

- Companion ad4m PR: [coasys/ad4m#855](https://github.com/coasys/ad4m/pull/855) — adds executor + `Ad4mModel.findAll`/`modelQuery` signal threading.
- Companion WE PR: [coasys/we#72](https://github.com/coasys/we/pull/72) — wires the signal through `SchemaRenderer` and ships a `scripts/sync-ad4m-branch.sh` for the same workflow.
- All three PRs share the branch name `feat/query-abort`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API methods now support optional request cancellation parameters
  * Enhanced error handling for cancelled requests across data-fetching operations

* **Tests**
  * Added test coverage for abort signal forwarding and error propagation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->