### PR TITLE
fix(community): refresh members list when a new agent joins

### DIFF
--- a/app/src/composables/useCommunityService.ts
+++ b/app/src/composables/useCommunityService.ts
@@ -517,9 +517,27 @@ export async function createCommunityService(): Promise<CommunityService> {
   }
   perspective.addListener('link-added', handleParticipantTracking);
 
+  // Refetch the members list whenever the signalling service learns about a
+  // DID we don't already have in `members`. The signalling service tracks
+  // every agent that broadcasts a heartbeat (including their "first-broadcast"
+  // on join), so this catches new joiners automatically — without polling
+  // and without waiting for the modal to remount.
+  const membersDidSet = computed(() => new Set(members.value.map((m) => m.did)));
+  const stopMembersWatcher = signallingService
+    ? watch(
+        () => Object.keys(signallingService.agents.value),
+        (signallingDids) => {
+          if (membersLoading.value) return;
+          const hasNew = signallingDids.some((did) => did && !membersDidSet.value.has(did));
+          if (hasNew) getMembers();
+        },
+      )
+    : null;
+
   // Cleanup function to remove all listeners
   function cleanup() {
     perspective.removeListener('link-added', handleParticipantTracking);
+    if (stopMembersWatcher) stopMembersWatcher();
   }
 
   getMembers();


### PR DESCRIPTION
## Summary

Members list in a neighbourhood didn't update when someone new joined — you had to remount the modal to see them. The community service was fetching `neighbourhood.otherAgents()` once on mount and never refreshing.

## Fix

Watch the signalling service's `agents` map and refetch \`getMembers()\` whenever a DID appears that we don't already have in \`members\`. The signalling service already tracks every agent that broadcasts a heartbeat (including the \"first-broadcast\" each agent sends on join), so this picks up new joiners reactively without polling and without changing any of the underlying ad4m primitives.

- No-op while \`membersLoading\` is true (avoids a feedback loop on the initial fetch)
- Watcher is unregistered alongside the existing \`link-added\` listener in \`cleanup()\`
- Single touchpoint in \`app/src/composables/useCommunityService.ts\`

## Test plan

- [x] \`vue-tsc --noEmit\` clean for the changed file (same set of pre-existing errors as dev — none introduced)
- [ ] Manual: two ad4m agents on the same neighbourhood, second agent joins after first has the members modal open → second agent appears without manual refresh
- [ ] Manual: ensure no regression in member-list pagination / search inside MembersModal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Community members list now automatically refreshes in real-time when new members become available, ensuring your roster stays current without manual intervention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->