### PR TITLE
fix(call): allow joining a WebRTC call without a microphone

### DIFF
--- a/app/src/components/call/controls/JoinCallControls.vue
+++ b/app/src/components/call/controls/JoinCallControls.vue
@@ -7,20 +7,21 @@
     <j-button
       variant="primary"
       size="lg"
-      :disabled="audioDisabled"
+      :disabled="streamLoading"
       :loading="joiningCall"
       @click="webrtcStore.joinRoom"
     >
       Join room!
     </j-button>
 
-    <div v-if="!streamLoading && audioDisabled" class="audio-disabled-warning">
+    <div v-if="!streamLoading && audioUnavailable" class="audio-disabled-warning">
       <j-flex gap="300" a="center">
         <j-icon name="mic-mute" size="md" color="warning-500" />
-        <j-text size="500" nomargin color="warning-500"> Audio is disabled </j-text>
+        <j-text size="500" nomargin color="warning-500"> No microphone available </j-text>
       </j-flex>
       <j-text size="400" nomargin color="warning-500">
-        Please enable a microphone in the browser to join the call.
+        You can still join and listen — enable a microphone in the browser
+        if you'd like to speak.
       </j-text>
     </div>
   </div>
@@ -41,8 +42,11 @@ const videoDisabled = computed(() => {
   return !stream.value || streamLoading.value;
 });
 
-const audioDisabled = computed(() => {
-  if (!stream.value || streamLoading.value || typeof stream.value.getAudioTracks !== 'function') return true;
+// Informational only — never gates the join button. Mic-less users can
+// join as listeners; the warning lets them know they won't be heard until
+// they grant mic access.
+const audioUnavailable = computed(() => {
+  if (!stream.value || typeof stream.value.getAudioTracks !== 'function') return true;
   return stream.value.getAudioTracks().length === 0;
 });
 </script>

--- a/app/src/stores/mediaDevicesStore.ts
+++ b/app/src/stores/mediaDevicesStore.ts
@@ -73,8 +73,51 @@ export const useMediaDevicesStore = defineStore(
         const audioConstraints = audioEnabled.value ? { deviceId: audioDeviceId } : false;
         const videoConstraints = videoEnabled.value ? { ...videoDimensions, deviceId: videoDeviceId } : false;
 
-        // Create the stream
-        stream.value = await navigator.mediaDevices.getUserMedia({ audio: audioConstraints, video: videoConstraints });
+        // Always request what the user actually has enabled first.
+        try {
+          stream.value = await navigator.mediaDevices.getUserMedia({
+            audio: audioConstraints,
+            video: videoConstraints,
+          });
+        } catch (firstErr) {
+          // Mic is the most common blocker (browser denial, no device, locked
+          // by another app). If audio was requested and failed, retry without
+          // it so the user can still join the call as a listener / camera-only
+          // participant rather than being stuck on the join screen.
+          //
+          // We only fall back when audio was the offending constraint (i.e.
+          // audioConstraints was truthy). If video was requested and that's
+          // what failed, the existing error path still applies.
+          const isMediaError =
+            firstErr instanceof DOMException &&
+            ['NotAllowedError', 'NotFoundError', 'NotReadableError', 'OverconstrainedError'].includes(firstErr.name);
+
+          if (audioConstraints && isMediaError) {
+            console.warn('Mic unavailable, falling back to no-audio stream:', firstErr);
+            try {
+              stream.value = videoConstraints
+                ? await navigator.mediaDevices.getUserMedia({ audio: false, video: videoConstraints })
+                : null;
+              // Reflect the fallback in the audio toggle so the UI stays
+              // consistent. The user can re-enable later via the device
+              // settings if they grant mic access.
+              audioEnabled.value = false;
+              mediaPermissions.value.microphone.granted = false;
+            } catch (secondErr) {
+              // Even the video-only / no-stream fallback failed (e.g. user
+              // explicitly asked for video and that's also denied, or no
+              // devices at all). Surface a null stream — the join button now
+              // allows joining as a passive listener, so the call can still
+              // proceed without any local media.
+              console.warn('Fallback stream also failed, joining without any local media:', secondErr);
+              stream.value = null;
+              audioEnabled.value = false;
+              videoEnabled.value = false;
+            }
+          } else {
+            throw firstErr;
+          }
+        }
 
         // Update request states
         microphone.requested = microphone.requested || audioEnabled.value;


### PR DESCRIPTION
## Summary

Users without microphone access were blocked from joining calls. The Join button was disabled whenever \`stream.value.getAudioTracks().length === 0\`, and \`createStream()\` threw hard when \`getUserMedia({ audio: true, ... })\` was denied. Net effect: anyone with the mic blocked at the OS / browser level (or who had revoked permission) was stuck on the join screen with a red \"Audio is disabled — please enable a microphone in the browser to join the call\" warning.

There's no architectural reason for that gate. SimplePeer accepts \`stream: undefined\`, the SFU join path just iterates the local stream's tracks (none = nothing to add), and every track-add path in \`webrtcStore.ts\` already guards on \`localStream.value\`.

## Changes

- **\`app/src/stores/mediaDevicesStore.ts\`** — \`createStream()\` now retries without audio on \`NotAllowedError\` / \`NotFoundError\` / \`NotReadableError\` / \`OverconstrainedError\`. If both attempts fail, the stream stays \`null\` and the audio/video toggles are reset to match.
- **\`app/src/components/call/controls/JoinCallControls.vue\`** — Join button is disabled only while \`streamLoading\` is true. The audio warning is reworded from \"Audio is disabled — please enable a microphone … to join the call\" to \"No microphone available — you can still join and listen, enable a microphone if you'd like to speak.\"

## Test plan

- [x] \`vue-tsc --noEmit\` clean for the changed files (same pre-existing errors as dev)
- [ ] Manual: deny mic permission in the browser → Join button is enabled, user joins as listener, can hear others, can later flip audio toggle if they regrant
- [ ] Manual: grant mic + camera → no regression in the normal join flow
- [ ] Manual: deny mic AND camera → Join button enabled, joins with no local media, receives remote streams