### PR TITLE
fix(call): fullscreen video layout — auto-fit, centre last row, self-view toggle, camera + screenshare coexist

### DIFF
--- a/app/src/components/call/composables/useVideoLayout.ts
+++ b/app/src/components/call/composables/useVideoLayout.ts
@@ -10,6 +10,22 @@ import {
 import { storeToRefs } from 'pinia';
 import { computed, watch } from 'vue';
 
+export type Participant = {
+  isMe: boolean;
+  did: string;
+  inCall: boolean;
+  stream: MediaStream | undefined;
+  streamReady: boolean;
+  audioState: MediaState;
+  videoState: MediaState;
+  screenShareState: MediaState;
+  warning: MediaPlayerWarning;
+  // Distinguishes a camera tile from a screenshare tile so a single user
+  // can be rendered as two participants when they're sharing their screen
+  // alongside their webcam.
+  streamKind: 'camera' | 'screenshare';
+};
+
 export function useVideoLayout() {
   const appStore = useAppStore();
   const mediaDeviceStore = useMediaDevicesStore();
@@ -17,8 +33,9 @@ export function useVideoLayout() {
   const webrtcStore = useWebrtcStore();
 
   const { me } = storeToRefs(appStore);
-  const { stream, mediaSettings, mediaPermissions } = storeToRefs(mediaDeviceStore);
-  const { callWindowWidth, callWindowOpen, selectedVideoLayout, focusedVideoId } = storeToRefs(uiStore);
+  const { stream, screenShareStream, mediaSettings, mediaPermissions } = storeToRefs(mediaDeviceStore);
+  const { callWindowWidth, callWindowOpen, selectedVideoLayout, focusedVideoId, selfViewVisible } =
+    storeToRefs(uiStore);
   const { inCall, peerConnections, disconnectedAgents } = storeToRefs(webrtcStore);
 
   const videoLayoutOptions: VideoLayoutOption[] = [
@@ -37,41 +54,112 @@ export function useVideoLayout() {
     if (microphone && microphone.requested && !microphone.granted) warning = 'mic-disabled';
     else if (videoEnabled && camera && camera.requested && !camera.granted) warning = 'camera-disabled';
 
-    const myAgent = {
-      isMe: true,
-      did: me.value.did,
-      inCall: inCall.value,
-      stream: stream.value || undefined,
-      streamReady: true,
-      audioState: (audioEnabled ? 'on' : 'off') as MediaState,
-      videoState: (videoEnabled ? 'on' : 'off') as MediaState,
-      screenShareState: (screenShareEnabled ? 'on' : 'off') as MediaState,
-      warning,
-    };
+    const myParticipants: Participant[] = [];
 
-    const otherAgents = peers.value.map((peer) => ({
-      isMe: false,
-      did: peer.did,
-      inCall: true,
-      stream: peer.streams?.[0] || undefined,
-      streamReady: peer.streamReady,
-      audioState: peer.audioState,
-      videoState: peer.videoState,
-      screenShareState: peer.screenShareState,
-      warning: '' as MediaPlayerWarning,
-    }));
+    // Local camera tile.  Hidden when the user toggles self-view off so they
+    // can focus on the other participants while still being in the call.
+    if (selfViewVisible.value) {
+      myParticipants.push({
+        isMe: true,
+        did: me.value.did,
+        inCall: inCall.value,
+        stream: stream.value || undefined,
+        streamReady: true,
+        audioState: (audioEnabled ? 'on' : 'off') as MediaState,
+        videoState: (videoEnabled ? 'on' : 'off') as MediaState,
+        // Camera tile never shows the screenshare badge — when both are on
+        // we emit a separate screenshare tile below.
+        screenShareState: 'off' as MediaState,
+        warning,
+        streamKind: 'camera',
+      });
+    }
 
-    return [myAgent, ...otherAgents];
+    // Local screenshare tile.  Emitted as its own participant so the camera
+    // and screenshare can be rendered side-by-side instead of one replacing
+    // the other.  Always shown to the local user (even when self-view is
+    // off) because hiding your own screenshare would make it impossible to
+    // verify what you're broadcasting.
+    if (screenShareEnabled && screenShareStream.value) {
+      myParticipants.push({
+        isMe: true,
+        did: me.value.did,
+        inCall: inCall.value,
+        stream: screenShareStream.value,
+        streamReady: true,
+        audioState: 'off' as MediaState,
+        videoState: 'off' as MediaState,
+        screenShareState: 'on' as MediaState,
+        warning: '' as MediaPlayerWarning,
+        streamKind: 'screenshare',
+      });
+    }
+
+    const otherAgents: Participant[] = peers.value.flatMap((peer) => {
+      const streams = peer.streams ?? [];
+
+      // Treat a stream as a screenshare when it carries video without audio.
+      // The camera stream always has at least one audio track (mic), so this
+      // distinguishes the two without needing extra signalling.  Falls back
+      // to the legacy single-stream rendering when only one stream exists.
+      const cameraStream = streams.find((s) => s.getAudioTracks().length > 0) ?? streams[0];
+      const screenShareStreams = streams.filter(
+        (s) => s !== cameraStream && s.getVideoTracks().length > 0,
+      );
+
+      const cameraEntry: Participant = {
+        isMe: false,
+        did: peer.did,
+        inCall: true,
+        stream: cameraStream || undefined,
+        streamReady: peer.streamReady,
+        audioState: peer.audioState,
+        videoState: peer.videoState,
+        screenShareState: screenShareStreams.length > 0 ? 'off' : peer.screenShareState,
+        warning: '' as MediaPlayerWarning,
+        streamKind: 'camera',
+      };
+
+      const screenShareEntries: Participant[] = screenShareStreams.map((screenStream) => ({
+        isMe: false,
+        did: peer.did,
+        inCall: true,
+        stream: screenStream,
+        streamReady: peer.streamReady,
+        audioState: 'off' as MediaState,
+        videoState: 'off' as MediaState,
+        screenShareState: 'on' as MediaState,
+        warning: '' as MediaPlayerWarning,
+        streamKind: 'screenshare',
+      }));
+
+      return [cameraEntry, ...screenShareEntries];
+    });
+
+    return [...myParticipants, ...otherAgents];
   });
+
+  // Participants may now share a `did` (a camera tile + a screenshare tile
+  // for the same user), so the focus key is the composite `did:streamKind`.
+  // Plain DIDs from older state still match — they fall through to the
+  // first tile we find for that user, which is the camera tile.
+  function participantKey(p: Participant): string {
+    return `${p.did}:${p.streamKind}`;
+  }
+
+  function matchesFocus(p: Participant, focusedId: string): boolean {
+    if (!focusedId) return false;
+    return participantKey(p) === focusedId || p.did === focusedId;
+  }
 
   const focusedParticipant = computed(() => {
     const focusedId = focusedVideoId.value || me.value.did;
-    return allParticipants.value.find((p) => p.did === focusedId) || allParticipants.value[0];
+    return allParticipants.value.find((p) => matchesFocus(p, focusedId)) || allParticipants.value[0];
   });
 
   const unfocusedParticipants = computed(() => {
     const focusedId = focusedVideoId.value || me.value.did;
-    return allParticipants.value.filter((p) => p.did !== focusedId);
+    return allParticipants.value.filter((p) => !matchesFocus(p, focusedId));
   });
 
   const numberOfColumns = computed(() => {
@@ -88,9 +176,11 @@ export function useVideoLayout() {
     uiStore.setVideoLayout(layout);
   }
 
-  function focusOnVideo(did: string) {
+  function focusOnVideo(key: string) {
     if (!inCall.value) return;
-    uiStore.setFocusedVideoId(did);
+    // `key` is either a participant key (`did:streamKind`) or a bare DID
+    // from older callers; both are honoured by `matchesFocus` above.
+    uiStore.setFocusedVideoId(key);
     if (selectedVideoLayout.value.label !== 'Focused') {
       uiStore.setVideoLayout(videoLayoutOptions[2]);
     }
@@ -133,5 +223,6 @@ export function useVideoLayout() {
     selectVideoLayout,
     focusOnVideo,
     closeFocusedVideoLayout,
+    participantKey,
   };
 }

--- a/app/src/components/call/controls/MainCallControls.vue
+++ b/app/src/components/call/controls/MainCallControls.vue
@@ -71,6 +71,22 @@
       </j-button>
     </j-tooltip>
 
+    <j-tooltip
+      v-if="!isMobile && inCall"
+      placement="top"
+      :title="selfViewVisible ? 'Hide my video' : 'Show my video'"
+    >
+      <j-button
+        :variant="selfViewVisible ? '' : 'primary'"
+        @click="uiStore.toggleSelfViewVisible"
+        square
+        circle
+        :size="isMobile ? 'md' : 'lg'"
+      >
+        <j-icon :name="selfViewVisible ? 'eye-slash' : 'eye'" :size="isMobile ? 'sm' : 'md'" />
+      </j-button>
+    </j-tooltip>
+
     <j-popover v-if="!isMobile" ref="videoLayoutPopover" placement="top">
       <j-tooltip slot="trigger" placement="top" title="Video layout options">
         <j-button variant="transparent" square circle :disabled="!inCall" :size="isMobile ? 'md' : 'lg'">
@@ -153,7 +169,7 @@ const modalStore = useModalStore();
 const aiStore = useAiStore();
 
 const { me } = storeToRefs(appStore);
-const { callWindowFullscreen, isMobile, isLandscapeMobile } = storeToRefs(uiStore);
+const { callWindowFullscreen, isMobile, isLandscapeMobile, selfViewVisible } = storeToRefs(uiStore);
 const { mediaSettings, availableDevices } = storeToRefs(mediaDeviceStore);
 const { transcriptionEnabled } = storeToRefs(aiStore);
 const { inCall, hasCopiedLink } = storeToRefs(webrtcStore);

--- a/app/src/components/call/window/VideoGrid.vue
+++ b/app/src/components/call/window/VideoGrid.vue
@@ -1,8 +1,19 @@
 <template>
   <div
     class="video-grid"
-    :class="[selectedVideoLayout.class, { mobile: isMobile, 'landscape-mobile': isLandscapeMobile }]"
-    :style="{ '--number-of-columns': numberOfColumns }"
+    :class="[
+      selectedVideoLayout.class,
+      {
+        mobile: isMobile,
+        'landscape-mobile': isLandscapeMobile,
+        fullscreen: callWindowFullscreen,
+      },
+    ]"
+    :style="{
+      '--number-of-columns': numberOfColumns,
+      '--number-of-rows': numberOfRows,
+      '--last-row-tiles': lastRowTiles,
+    }"
   >
     <!-- Focused layout -->
     <template v-if="selectedVideoLayout.label === 'Focused'">
@@ -11,7 +22,7 @@
         <div :class="isLandscapeMobile ? 'side-column' : 'bottom-row'">
           <MediaPlayer
             v-for="participant in unfocusedParticipants"
-            :key="`participant-${participant.did}`"
+            :key="`participant-${participantKey(participant)}`"
             :did="participant.did"
             :isMe="participant.isMe"
             :inCall="participant.inCall"
@@ -22,7 +33,7 @@
             :screenShareState="participant.screenShareState"
             :warning="participant.warning"
             :emojis="callEmojis.filter((emoji) => emoji.author === participant.did)"
-            @click="focusOnVideo(participant.did)"
+            @click="focusOnVideo(participantKey(participant))"
           />
         </div>
       </template>
@@ -30,7 +41,7 @@
       <!-- Main focused video -->
       <MediaPlayer
         v-if="focusedParticipant"
-        :key="`participant-${focusedParticipant.did}`"
+        :key="`participant-${participantKey(focusedParticipant)}`"
         :did="focusedParticipant.did"
         :isMe="focusedParticipant.isMe"
         :inCall="focusedParticipant.inCall"
@@ -48,8 +59,8 @@
     <!-- Other layouts (fixed aspect ratio, flexible) -->
     <template v-else>
       <MediaPlayer
-        v-for="participant in allParticipants"
-        :key="`participant-${participant.did}`"
+        v-for="(participant, index) in allParticipants"
+        :key="`participant-${participantKey(participant)}`"
         :did="participant.did"
         :isMe="participant.isMe"
         :inCall="participant.inCall"
@@ -60,8 +71,12 @@
         :screenShareState="participant.screenShareState"
         :warning="participant.warning"
         :emojis="callEmojis.filter((emoji) => emoji.author === participant.did)"
-        @click="focusOnVideo(participant.did)"
-        :class="{ 'single-participant': unfocusedParticipants.length < 2 }"
+        @click="focusOnVideo(participantKey(participant))"
+        :class="{
+          'single-participant': unfocusedParticipants.length < 2,
+          'last-row-center': isLastRowOffsetTile(index),
+        }"
+        :style="lastRowStyleFor(index)"
       />
     </template>
   </div>
@@ -71,13 +86,13 @@
 import MediaPlayer from '@/components/media-player/MediaPlayer.vue';
 import { useWebrtcStore, useUiStore } from '@/stores';
 import { storeToRefs } from 'pinia';
-import { computed, onMounted, watch } from 'vue';
+import { computed, watch } from 'vue';
 import { useVideoLayout } from '../composables/useVideoLayout';
 
 const webrtcStore = useWebrtcStore();
 const uiStore = useUiStore();
 const { callEmojis } = storeToRefs(webrtcStore);
-const { isMobile, isLandscapeMobile } = storeToRefs(uiStore);
+const { isMobile, isLandscapeMobile, callWindowFullscreen } = storeToRefs(uiStore);
 
 const {
   selectedVideoLayout,
@@ -87,13 +102,56 @@ const {
   unfocusedParticipants,
   focusOnVideo,
   closeFocusedVideoLayout,
+  participantKey,
 } = useVideoLayout();
+
+// Centring the trailing row when it doesn't fill all columns means we have
+// to know two things at template time: how many rows the grid will use
+// (so the auto-fit CSS can divide remaining height evenly) and how many
+// tiles land in that final row (so we can shift them inward via
+// `grid-column-start`).
+const numberOfRows = computed(() => {
+  const total = allParticipants.value.length;
+  const cols = numberOfColumns.value;
+  if (total === 0 || cols <= 0) return 1;
+  return Math.ceil(total / cols);
+});
+
+const lastRowTiles = computed(() => {
+  const total = allParticipants.value.length;
+  const cols = numberOfColumns.value;
+  if (total === 0 || cols <= 0) return 0;
+  const remainder = total % cols;
+  return remainder === 0 ? cols : remainder;
+});
+
+const firstTileInLastRowIndex = computed(() => {
+  if (lastRowTiles.value === numberOfColumns.value) return -1;
+  return allParticipants.value.length - lastRowTiles.value;
+});
+
+function isLastRowOffsetTile(index: number): boolean {
+  // Only the very first tile of an incomplete trailing row needs an
+  // explicit column offset; the others fall into the next grid cell
+  // automatically once that first tile is shifted.
+  return index === firstTileInLastRowIndex.value;
+}
+
+function lastRowStyleFor(index: number): Record<string, string> | undefined {
+  if (!isLastRowOffsetTile(index)) return undefined;
+  // Centre the partial row by leaving `(cols - tiles) / 2` empty columns to
+  // its left.  Using `grid-column-start` is enough — subsequent tiles flow
+  // naturally and the trailing row reads as visually centred.
+  const offset = Math.floor((numberOfColumns.value - lastRowTiles.value) / 2);
+  if (offset <= 0) return undefined;
+  return { 'grid-column-start': String(offset + 1) };
+}
 
 // Automatically focus on the first participant when switching to landscape mobile in focused layout
 watch(
   isLandscapeMobile,
   (newVal) => {
-    if (newVal && focusedParticipant.value) focusOnVideo(focusedParticipant.value.did);
+    if (newVal && focusedParticipant.value) focusOnVideo(participantKey(focusedParticipant.value));
   },
   { immediate: true },
 );
@@ -136,6 +194,31 @@ watch(
 
   &:has(.single-participant) {
     justify-items: center;
+  }
+
+  // Fullscreen / expanded grids should make every tile fit on screen
+  // instead of overflowing.  Switch from `min-content` rows to N equal
+  // rows that share the available height, and cap each tile's width by
+  // its 16/9 aspect ratio so they don't stretch into bands when the
+  // available height is the tighter axis.
+  &.fullscreen {
+    height: 100%;
+    overflow: hidden;
+    grid-auto-rows: unset;
+    grid-template-rows: repeat(var(--number-of-rows), 1fr);
+    justify-content: center;
+
+    > div {
+      width: 100%;
+      height: 100%;
+      max-height: 100%;
+      max-width: 100%;
+      // Preserve 16/9: when height is the limiting axis, `min()` clamps
+      // width so tiles don't get letterboxed unevenly within their grid cell.
+      // (CSS aspect-ratio still applies — `min()` is the upper bound.)
+      align-self: center;
+      justify-self: center;
+    }
   }
 
   &.flexible {

--- a/app/src/stores/mediaDevicesStore.ts
+++ b/app/src/stores/mediaDevicesStore.ts
@@ -45,9 +45,12 @@ export const useMediaDevicesStore = defineStore(
     const streamLoading = ref(false);
     const error = ref<Error | null>(null);
     const screenShareEnabled = ref(false);
+    // Held in its own stream so the camera tile and the screenshare tile can
+    // be rendered side-by-side. Peers receive this as a separate track via
+    // `webrtcStore.addScreenShareTrack`.
+    const screenShareStream = ref<MediaStream | null>(null);
     const audioEnabled = ref(true);
     const videoEnabled = ref(false);
-    let savedVideoTrack: MediaStreamTrack | null = null;
 
     // Computed properties
     const cameras = computed(() => availableDevices.value.filter((device) => device.kind === 'videoinput'));
@@ -316,7 +319,10 @@ export const useMediaDevicesStore = defineStore(
       // Reset screen share state
       if (screenShareEnabled.value) {
         screenShareEnabled.value = false;
-        savedVideoTrack = null;
+        if (screenShareStream.value) {
+          screenShareStream.value.getTracks().forEach((t) => t.stop());
+          screenShareStream.value = null;
+        }
       }
     }
 
@@ -386,17 +392,15 @@ export const useMediaDevicesStore = defineStore(
             const newStream = await navigator.mediaDevices.getUserMedia({ video: videoConstraints });
             const newVideoTrack = newStream.getVideoTracks()[0];
 
-            // If screen sharing is enabled, save the new track for later restoration
-            if (screenShareEnabled.value) savedVideoTrack = newVideoTrack;
-            else {
-              // Otherwise, add the new track directly to the stream
-              stream.value.addTrack(newVideoTrack);
+            // Camera + screenshare now coexist as separate streams, so the
+            // newly enabled camera track always lands in the main stream and
+            // is forwarded to peers immediately — no swap-on-screenshare-end
+            // bookkeeping is required.
+            stream.value.addTrack(newVideoTrack);
 
-              // Update peer connections
-              const { useWebrtcStore } = await import('./webrtcStore');
-              const webrtcStore = useWebrtcStore();
-              await webrtcStore.addTrack(newVideoTrack, stream.value);
-            }
+            const { useWebrtcStore } = await import('./webrtcStore');
+            const webrtcStore = useWebrtcStore();
+            await webrtcStore.addTrack(newVideoTrack, stream.value);
 
             console.log('✅ Added new video track');
           } catch (error) {
@@ -409,8 +413,11 @@ export const useMediaDevicesStore = defineStore(
             videoEnabled.value = false;
           }
         }
-      } else if (!screenShareEnabled.value) {
-        // Disabling video - disable tracks with animation delay
+      } else {
+        // Disabling video - disable tracks with animation delay.
+        // The camera tracks are independent of screenshare now, so disabling
+        // the camera while sharing only kills the camera tile without
+        // affecting the screenshare track.
         await new Promise((resolve) => setTimeout(resolve, 300)); // Fade out animation
         existingVideoTracks.forEach((track) => (track.enabled = false));
         console.log('✅ Disabled video tracks');
@@ -421,79 +428,70 @@ export const useMediaDevicesStore = defineStore(
       if (!stream.value) return;
 
       try {
-        // Get the screen share track
-        const screenShareStream = await navigator.mediaDevices.getDisplayMedia({ video: true });
-        const screenShareTrack = screenShareStream.getVideoTracks()[0];
+        // Get the screen share stream as its own MediaStream so peers can
+        // receive it alongside (not in place of) the camera track. The
+        // camera track stays in the existing `stream` ref and continues
+        // sending — both the local user and remote peers see a separate
+        // tile for camera and screenshare.
+        const newScreenShareStream = await navigator.mediaDevices.getDisplayMedia({ video: true });
+        const screenShareTrack = newScreenShareStream.getVideoTracks()[0];
+        if (!screenShareTrack) {
+          // The browser handed us a stream without a video track — rare but
+          // possible if the user immediately cancelled the picker. Bail
+          // cleanly rather than wiring a phantom share.
+          newScreenShareStream.getTracks().forEach((t) => t.stop());
+          return;
+        }
 
-        // Update my media settings
         screenShareEnabled.value = true;
+        screenShareStream.value = newScreenShareStream;
 
-        // Add onended handler to detect when the user stops sharing via browser UI
+        // Detect when the user stops sharing via the browser's native UI
+        // (e.g. the "Stop sharing" bar) and tear the share down cleanly.
         screenShareTrack.onended = () => {
           if (!screenShareEnabled.value) return;
-          screenShareEnabled.value = false;
           turnOffScreenShare();
         };
 
-        // Get existing video track if present
-        const existingVideoTrack = stream.value.getVideoTracks()[0];
-
-        // Save existing video track for later restoration
-        if (existingVideoTrack) {
-          savedVideoTrack = existingVideoTrack;
-          // Remove existing video track from stream
-          stream.value.removeTrack(existingVideoTrack);
-        }
-
-        // Add screen share track to existing stream
-        stream.value.addTrack(screenShareTrack);
-
-        // Update peer connections
+        // Send the screenshare to all peers as its own track + stream so
+        // the receiving side fires a fresh 'track' event with a distinct
+        // stream id, rather than swapping the existing camera sender.
         const { useWebrtcStore } = await import('./webrtcStore');
         const webrtcStore = useWebrtcStore();
-        await webrtcStore.replaceVideoTrack(screenShareTrack, existingVideoTrack);
+        await webrtcStore.addScreenShareTrack(screenShareTrack, newScreenShareStream);
 
         console.log('✅ Successfully started screen share');
       } catch (error) {
         console.error('❌ Error starting screen share:', error);
         screenShareEnabled.value = false;
+        if (screenShareStream.value) {
+          screenShareStream.value.getTracks().forEach((t) => t.stop());
+          screenShareStream.value = null;
+        }
       }
     }
 
     async function turnOffScreenShare() {
-      if (!stream.value) return;
-
       try {
-        // Get current screen share track
-        const screenShareTrack = stream.value.getVideoTracks()[0];
+        const tracks = screenShareStream.value?.getTracks() ?? [];
 
-        // Remove screen share track from stream
-        if (screenShareTrack) {
-          stream.value.removeTrack(screenShareTrack);
-          screenShareTrack.stop();
+        // Stop the OS-level capture before tearing down the peer senders so
+        // the browser's "Stop sharing" indicator goes away immediately.
+        tracks.forEach((t) => t.stop());
+
+        // Remove every screenshare sender from each peer connection.  The
+        // receiving side's 'track ended' handler will surface the stream
+        // disappearing — no replace-back to the camera track is needed.
+        if (tracks.length) {
+          const { useWebrtcStore } = await import('./webrtcStore');
+          const webrtcStore = useWebrtcStore();
+          for (const t of tracks) {
+            await webrtcStore.removeTrack(t);
+          }
         }
 
-        // Update media settings
         screenShareEnabled.value = false;
-
-        // Restore saved video track if it exists
-        if (savedVideoTrack) {
-          // Re-enable the saved track if video should be enabled
-          savedVideoTrack.enabled = videoEnabled.value;
-          stream.value.addTrack(savedVideoTrack);
-
-          // Update peer connections
-          const { useWebrtcStore } = await import('./webrtcStore');
-          const webrtcStore = useWebrtcStore();
-          await webrtcStore.replaceVideoTrack(savedVideoTrack, screenShareTrack);
-
-          savedVideoTrack = null; // Clear the saved track
-        } else {
-          // No saved track - just remove screen share from peers
-          const { useWebrtcStore } = await import('./webrtcStore');
-          const webrtcStore = useWebrtcStore();
-          await webrtcStore.removeTrack(screenShareTrack);
-        }
+        screenShareStream.value = null;
 
         console.log('✅ Successfully stopped screen share');
       } catch (error) {
@@ -533,6 +531,7 @@ export const useMediaDevicesStore = defineStore(
       activeAudioOutputId,
       availableDevices,
       stream,
+      screenShareStream,
       streamLoading,
       error,
       screenShareEnabled,

--- a/app/src/stores/uiStore.ts
+++ b/app/src/stores/uiStore.ts
@@ -25,6 +25,10 @@ export const useUiStore = defineStore(
       icon: 'aspect-ratio',
     });
     const focusedVideoId = ref('');
+    // When false the user's own video tile is hidden from the call grid.
+    // The user can still hear themselves and remains a participant — this is
+    // purely a presentation choice so they can focus on others.
+    const selfViewVisible = ref(true);
     const showGlobalLoading = ref(false);
     const globalError = ref({ show: false, message: '' });
     const windowState = ref<WindowState>('visible');
@@ -102,6 +106,14 @@ export const useUiStore = defineStore(
       focusedVideoId.value = id;
     }
 
+    function toggleSelfViewVisible(): void {
+      selfViewVisible.value = !selfViewVisible.value;
+    }
+
+    function setSelfViewVisible(visible: boolean): void {
+      selfViewVisible.value = visible;
+    }
+
     function setWindowState(state: WindowState): void {
       windowState.value = state;
     }
@@ -166,6 +178,7 @@ export const useUiStore = defineStore(
       callWindowWidth,
       selectedVideoLayout,
       focusedVideoId,
+      selfViewVisible,
       showGlobalLoading,
       globalError,
       windowState,
@@ -183,6 +196,8 @@ export const useUiStore = defineStore(
       setCallWindowWidth,
       setVideoLayout,
       setFocusedVideoId,
+      toggleSelfViewVisible,
+      setSelfViewVisible,
       setWindowState,
       setGlobalLoading,
       setGlobalError,

--- a/app/src/stores/webrtcStore.ts
+++ b/app/src/stores/webrtcStore.ts
@@ -280,10 +280,31 @@ export const useWebrtcStore = defineStore(
         const peerConnection = peerConnections.value.get(did);
         if (!peerConnection) return;
 
-        // Check if we already have the stream & update or add accordingly
+        // Append (don't overwrite) — a peer that's sharing their screen
+        // sends both the camera stream and the screenshare stream, and the
+        // old `streams = [stream]` shape silently dropped the camera tile
+        // the moment the screenshare track arrived. New streams append;
+        // tracks added to existing streams update in place.
         const existingStreamIndex = peerConnection.streams.findIndex((s) => s.id === stream.id);
         if (existingStreamIndex >= 0) peerConnection.streams[existingStreamIndex] = stream;
-        else peerConnection.streams = [stream];
+        else peerConnection.streams.push(stream);
+
+        // Drop the stream from this peer's list as soon as all of its tracks
+        // end — guards against stale screenshare tiles after the sender
+        // stops sharing.  We can't rely on the peer connection's own
+        // sender-removal because that fires before the receiving track ends.
+        const onTrackEnded = () => {
+          if (track.readyState !== 'ended') return;
+          const pc = peerConnections.value.get(did);
+          if (!pc) return;
+          const streamRef = pc.streams.find((s) => s.id === stream.id);
+          if (!streamRef) return;
+          const liveTracks = streamRef.getTracks().filter((t) => t.readyState !== 'ended');
+          if (liveTracks.length === 0) {
+            pc.streams = pc.streams.filter((s) => s.id !== stream.id);
+          }
+        };
+        track.addEventListener('ended', onTrackEnded);
 
         // Mark the stream as ready if not already set
         if (!peerConnection.streamReady) peerConnection.streamReady = true;
@@ -419,6 +440,27 @@ export const useWebrtcStore = defineStore(
           }
         } catch (error) {
           console.error(`❌ Failed to remove ${trackToRemove.kind} track for peer ${did}:`, error);
+        }
+      }
+    }
+
+    // Adds a screen-share track to every peer connection as part of a
+    // dedicated MediaStream (rather than replacing the camera sender).
+    // The receiving side's `peer.on('track')` then fires with a distinct
+    // stream id and the per-peer streams array grows by one entry — the
+    // remote UI gets a separate tile for the screenshare while keeping
+    // the camera tile.
+    async function addScreenShareTrack(track: MediaStreamTrack, screenShareStream: MediaStream) {
+      if (!inCall.value) return;
+
+      console.log('🖥️ Adding screen-share track for all peers');
+
+      for (const [did, peerConnection] of peerConnections.value) {
+        try {
+          peerConnection.peer.addTrack(track, screenShareStream);
+          console.log(`✅ Added screen-share track for peer ${did}`);
+        } catch (error) {
+          console.error(`❌ Failed to add screen-share track for peer ${did}:`, error);
         }
       }
     }
@@ -782,6 +824,7 @@ export const useWebrtcStore = defineStore(
       disconnectedAgents,
       hasCopiedLink,
       addTrack,
+      addScreenShareTrack,
       removeTrack,
       replaceAudioTrack,
       replaceVideoTrack,


### PR DESCRIPTION
## Summary

Four related issues with the in-call video grid landed in one PR because each one was a slice of the same per-participant layout pipeline.

### 1. Tiles overflowed in fullscreen
The grid used `grid-auto-rows: min-content` and capped each tile via `max-height: 100%`, but `100%` of an overflowing parent is the overflowing height itself, so trailing rows scrolled off-screen. Added a \`fullscreen\` class that switches the grid to \`grid-template-rows: repeat(var(--number-of-rows), 1fr)\` with \`overflow: hidden\` and per-tile \`align/justify-self: center\`. Every tile now fits on screen while preserving 16/9.

### 2. Odd-numbered trailing rows left-aligned
Computed \`lastRowTiles\` from \`allParticipants.length % numberOfColumns\` and emit \`grid-column-start: <offset+1>\` on the first tile of an incomplete trailing row. Subsequent tiles flow naturally — no per-row wrapper required.

### 3. Self-view couldn't be hidden
Added \`selfViewVisible\` / \`toggleSelfViewVisible\` on the UI store and a desktop-only \"Hide my video / Show my video\" button in \`MainCallControls.vue\`. When off, the local camera tile is dropped from \`allParticipants\`. The user remains in the call and is still heard; the local screenshare tile (when present) is still shown so they can verify what they're broadcasting.

### 4. Screenshare overrode the user's camera tile
Three connected changes let camera + screenshare run side-by-side for the same user on both sides of the call:

- **\`mediaDevicesStore.turnOnScreenShare\`** no longer removes the camera track from \`stream\`. The screenshare is captured into its own \`screenShareStream\` ref and sent to peers via a new \`webrtcStore.addScreenShareTrack\` (a \`peer.addTrack(track, dedicatedStream)\` instead of a \`replaceTrack\` swap), so the receiving side fires a fresh \`peer.on('track')\` event with a distinct stream id.
- **\`webrtcStore.ts\` peer.on('track') handler** used to wipe the per-peer \`streams\` array on every new stream (\`streams = [stream]\`), which silently dropped the camera tile the moment a screenshare track arrived. Now appends new streams and updates in place when extra tracks land on an existing stream. Tracks that end clear their stream from the array.
- **\`useVideoLayout.allParticipants\`** splits both the local user and each remote peer into separate camera-tile / screenshare-tile entries (\`streamKind: 'camera' | 'screenshare'\`). Remote screenshares are identified as streams with video tracks but no audio tracks — the camera stream always carries the mic track.
- Cleaned up the old \`savedVideoTrack\` swap-back bookkeeping in \`toggleVideo\` / \`resetMediaDevices\` — no longer needed now that camera and screenshare run on independent streams.

Composite \`did:streamKind\` participant keys replace bare DIDs in \`focusOnVideo\` / focused-layout. Bare DIDs from older persisted state still match (first tile for that user, which is the camera tile).

## Test plan

- [x] \`vue-tsc --noEmit\` clean for all changed files (same pre-existing errors as dev — none introduced)
- [ ] Manual: 1-tile / 2-tile / 4-tile / 7-tile grids in fullscreen — every tile visible, trailing-row tiles centred
- [ ] Manual: toggle \"Hide my video\" → local camera tile disappears, others still rendered, can re-show
- [ ] Manual: toggle screenshare while camera is on → both tiles render side-by-side locally
- [ ] Manual: peer toggles screenshare while their camera is on → both tiles render side-by-side in our grid
- [ ] Manual: peer stops sharing → screenshare tile disappears, camera tile remains