### PR TITLE
refactor: replace resolveLanguage with resolveLiteral (companion to coasys/ad4m#842)

### DIFF
--- a/docs/src/create-flux-plugin/basics/subjects.md
+++ b/docs/src/create-flux-plugin/basics/subjects.md
@@ -48,21 +48,18 @@ export default class Todo {
   @Property({
     through: 'rdf://title',
     writable: true,
-    resolveLanguage: 'literal',
   })
   title: string;
 
   @Property({
     through: 'rdf://description',
     writable: true,
-    resolveLanguage: 'literal',
   })
   desc: string;
 
   @Property({
     through: 'rdf://status',
     writable: true,
-    resolveLanguage: 'literal',
   })
   done: boolean;
 }

--- a/packages/api/src/community/index.ts
+++ b/packages/api/src/community/index.ts
@@ -1,9 +1,8 @@
 import { Ad4mModel, HasMany, Flag, Model, Property, fileToDataUri } from '@coasys/ad4m';
-import { community, languages } from '@coasys/flux-constants';
+import { community } from '@coasys/flux-constants';
 import { EntryType } from '@coasys/flux-types';
 import Channel from '../channel';
 
-const { FILE_STORAGE_LANGUAGE } = languages;
 const { DESCRIPTION, IMAGE, NAME, THUMBNAIL, ENTRY_TYPE, CHANNEL } = community;
 
 interface FileData {
@@ -25,14 +24,14 @@ export class Community extends Ad4mModel {
 
   @Property({
     through: IMAGE,
-    resolveLanguage: FILE_STORAGE_LANGUAGE,
+    resolveLiteral: false,
     transform: fileToDataUri,
   })
   image: string | FileData;
 
   @Property({
     through: THUMBNAIL,
-    resolveLanguage: FILE_STORAGE_LANGUAGE,
+    resolveLiteral: false,
     transform: fileToDataUri,
   })
   thumbnail: string | FileData;

--- a/packages/api/src/post/index.ts
+++ b/packages/api/src/post/index.ts
@@ -1,11 +1,10 @@
 import { Ad4mModel, HasMany, Flag, Model, Property, fileToDataUri } from '@coasys/ad4m';
-import { community, languages } from '@coasys/flux-constants';
+import { community } from '@coasys/flux-constants';
 
 import { EntryType } from '@coasys/flux-types';
 import Message from '../message';
 
 const { BODY, IMAGE, TITLE, URL, ENTRY_TYPE } = community;
-const { FILE_STORAGE_LANGUAGE } = languages;
 
 @Model({ name: 'Post' })
 export class Post extends Ad4mModel {
@@ -20,7 +19,7 @@ export class Post extends Ad4mModel {
 
   @Property({
     through: IMAGE,
-    resolveLanguage: FILE_STORAGE_LANGUAGE,
+    resolveLiteral: false,
     transform: fileToDataUri,
   })
   image: string;

--- a/views/kanban-view/src/components/Board/TaskModel.ts
+++ b/views/kanban-view/src/components/Board/TaskModel.ts
@@ -4,7 +4,6 @@ import { Ad4mModel, Model, Property, HasMany } from '@coasys/ad4m';
 export class Task extends Ad4mModel {
   @Property({
     through: 'rdf://name',
-    resolveLanguage: 'literal',
     required: true,
     writable: true,
     initial: 'New task',

--- a/views/table-view/src/components/NewClass/NewClass.tsx
+++ b/views/table-view/src/components/NewClass/NewClass.tsx
@@ -248,7 +248,7 @@ async function buildSHACLShape(
     };
 
     if (language) {
-      propShape.resolveLanguage = language;
+      propShape.resolveLiteral = false;
     }
 
     if (options.length > 0) {


### PR DESCRIPTION
## Summary

Companion PR to [coasys/ad4m#842](https://github.com/coasys/ad4m/pull/842) — typed RDF literals and `resolveLanguage → resolveLiteral` migration.

- `resolveLanguage: 'literal'` removed from kanban TaskModel and docs examples (now the implicit default)
- `resolveLanguage: FILE_STORAGE_LANGUAGE` → `resolveLiteral: false` on community image/thumbnail and post image properties
- `propShape.resolveLanguage` → `propShape.resolveLiteral` in table-view NewClass dynamic shape builder

## Test plan

- [ ] Verify kanban-view task creation still works
- [ ] Verify community image upload/display
- [ ] Verify post image upload/display
- [ ] Verify table-view class creation with language properties

🤖 Generated with [Claude Code](https://claude.com/claude-code)