### PR TITLE
docs: add CLAUDE.md with CI lockfile gotcha

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,28 @@
+# Flux — Claude Code Context
+
+## CI / Build
+
+### Never commit `pnpm-lock.yaml` changes on feature branches that use the ad4m link
+
+`scripts/build-with-ad4m-link.sh` overrides `@coasys/ad4m` and `@coasys/ad4m-connect` to
+`file:` paths pointing at a locally-cloned ad4m repo. If the committed lockfile contains
+npm-registry entries for those packages (e.g. `@coasys/ad4m-connect: 0.13.0-foo`), pnpm
+must transition them to `file:` entries during `pnpm install --no-frozen-lockfile`. During
+that re-resolution it detects `ad4m/pnpm-workspace.yaml` and absorbs the entire ad4m
+workspace, then resolves transitive `file:` deps relative to the **ad4m** workspace root
+instead of the flux root — producing double-path errors like
+`Could not install from "/opt/build/repo/ad4m/ad4m/core"`.
+
+**Cached Netlify builds (existing branches) never hit this** because node_modules already
+has the npm versions installed and pnpm skips re-resolution. **Fresh-cache builds (new
+branches) always hit it.** This is why the issue only surfaces on new branches.
+
+**Rule:** when working on a branch that bumps or changes any `@coasys/ad4m*` version,
+reset `pnpm-lock.yaml` to the `dev` baseline before pushing:
+
+```bash
+git checkout origin/dev -- pnpm-lock.yaml
+```
+
+Let CI regenerate the lockfile from scratch rather than committing one with stale npm
+entries for packages that the build script will override to `file:` paths.


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` to the flux repo root so Claude Code automatically loads project-specific context at the start of every session
- Documents the pnpm workspace-absorption CI failure that occurs on fresh Netlify builds when a branch commits a `pnpm-lock.yaml` containing npm-registry entries for packages that `build-with-ad4m-link.sh` overrides to `file:` paths
- Explains why it only surfaces on new branches (no Netlify cache) and not on existing ones (cached `node_modules` skips re-resolution)
- Includes the one-line fix: `git checkout origin/dev -- pnpm-lock.yaml`

## Context

Discovered while building the `feat/demo-fast-path` branch — the first fresh-cache Netlify build in a while. Root cause took several hours to identify; this doc ensures it doesn't happen again.

## Test plan

- [ ] Verify `CLAUDE.md` appears in Claude Code's context at session start when opened in the flux repo
- [ ] No functional code changes — no build or test steps required
