### PR TITLE
fix(api): stop leaking a transient '<name>-meta' perspective during c…

### DIFF
--- a/packages/api/src/createCommunity.ts
+++ b/packages/api/src/createCommunity.ts
@@ -64,7 +64,7 @@ export default async function createCommunity({
     const templateAddress = linkLangAddress || langs?.[0];
     if (!templateAddress) throw new Error('No link language templates available to publish neighbourhood.');
     const linkLanguage = await client.languages.applyTemplateAndPublish(templateAddress, templateData);
-    const metaLinks = await createNeighbourhoodMeta(client, name, description, author);
+    const metaLinks = await createNeighbourhoodMeta(client, perspective.uuid, name, description, author);
 
     let sharedUrl = perspective.sharedUrl;
 

--- a/packages/utils/src/createNeighbourhoodMeta.ts
+++ b/packages/utils/src/createNeighbourhoodMeta.ts
@@ -4,13 +4,11 @@ const { CREATOR, DESCRIPTION, NAME, SELF, CREATED_AT } = community;
 
 export async function createNeighbourhoodMeta(
   client: Ad4mClient,
+  perspectiveUuid: string,
   name: string,
   description: string,
   author: string,
 ): Promise<LinkExpression[]> {
-  //Create the perspective to hold our meta
-  const perspective = await client.perspective.add(`${name}-meta`);
-
   const nameExpression = await client.expression.create(name, 'literal');
   const createdAtExpression = await client.expression.create(new Date().toISOString(), 'literal');
 
@@ -51,11 +49,17 @@ export async function createNeighbourhoodMeta(
     );
   }
 
-  //Create the links on the perspective
-  await client.perspective.addLinks(perspective.uuid, expressionLinks);
-
-  //Get the signed links back
-  const perspectiveSnapshot = await client.perspective.snapshotByUUID(perspective.uuid);
-  await client.perspective.remove(perspective.uuid);
-  return Object.values(perspectiveSnapshot!.links);
+  // Sign the links by round-tripping them through the community's own perspective
+  // (addLinks already returns fully signed LinkExpressions) instead of a dedicated
+  // scratch perspective. Creating a separate perspective here — even briefly —
+  // registers it with the executor and broadcasts perspective-added/removed events to
+  // every connected client, which is what caused a transient "<name>-meta" entry to
+  // flash in host apps (e.g. WE's sidebar) that list all perspectives.
+  // Status must be 'local': perspectiveUuid may belong to an already-published
+  // neighbourhood (e.g. a WE space Flux is attaching to), and only 'shared' links are
+  // included in the link language's outbound sync — 'local' keeps this transient
+  // signing round-trip from ever reaching peers.
+  const signedLinks = await client.perspective.addLinks(perspectiveUuid, expressionLinks, 'local');
+  await client.perspective.removeLinks(perspectiveUuid, signedLinks);
+  return signedLinks;
 }


### PR DESCRIPTION
# PR: Stop leaking a transient `<name>-meta` perspective during community creation

## Summary

When creating a community, Flux would briefly register a real, named AD4M
perspective (`${name}-meta`) purely to sign the neighbourhood's meta links (name,
description, creator, created-at), then delete it a moment later. Registering and
deleting a perspective isn't a local-only operation — it broadcasts
`PerspectiveAdded`/`PerspectiveRemoved` events to every client connected to the same
AD4M executor. In WE (which embeds Flux and lists all perspectives in its sidebar),
this caused a transient `<name>-meta` entry to flash into the sidebar alongside the
real new community, which then lingered until a full app reboot forced WE to refetch
the true perspective list.

The scratch perspective turned out to be leftover debt from a 2021 AD4M API change:
at the time, the executor exposed a standalone `expressionSign` mutation that could
sign arbitrary data without needing a perspective at all. When that mutation was
removed, the workaround was to spin up a disposable perspective just to reach
`addLinks`' signing side effect. `addLinks` already returns fully signed
`LinkExpression[]` directly — the scratch perspective was never structurally
necessary, it was only needed because, at the time the meta links were originally
built as a discovery/preview mechanism (`neighbourhood.meta`, read by
`getPerspectiveMeta.ts` without joining), there wasn't yet a "real" perspective handy
to sign against early in the flow.

By the time `createNeighbourhoodMeta` runs today, the community's own perspective
already exists (created a few lines earlier in `createCommunity.ts`), so the fix
signs the meta links against that perspective directly and retracts them
immediately with `removeLinks` — a link-level operation, not a perspective-level
one, so it never triggers the events that were leaking into WE's sidebar.

## Changes

- **`packages/utils/src/createNeighbourhoodMeta.ts`** — takes the community's
  `perspectiveUuid` as a parameter instead of creating (and later deleting) its own
  `${name}-meta` perspective. Signs the meta links via
  `client.perspective.addLinks(perspectiveUuid, links, 'local')` and immediately
  retracts them via `removeLinks`, using the signed return value directly instead of
  re-fetching via `snapshotByUUID`.
  - Status is explicitly `'local'` rather than the default `'shared'`: the AD4M
    executor only includes `'shared'`-status links in a perspective's outbound
    neighbourhood sync (`rust-executor/src/perspectives/perspective_instance.rs:852`).
    Since `perspectiveUuid` can belong to an already-published neighbourhood (e.g. a
    WE space that Flux is attaching a community to), `'local'` is required to keep
    this transient signing round-trip from ever reaching peers — with the old
    default it would have briefly broadcast these meta links to anyone already
    joined to that neighbourhood.
- **`packages/api/src/createCommunity.ts`** — passes `perspective.uuid` through to
  `createNeighbourhoodMeta` (the perspective already exists at this point in the
  flow, either freshly created or resolved from the caller-supplied
  `perspectiveUuid`).

## Known follow-ups

- `app/src/__tests__/core/methods/createNeighbourhoodMeta.ts` and
  `app/src/__tests__/store/data/actions/createCommunity.ts` reference a
  `@/core/methods/createNeighbourhoodMeta` module and `@/store/data` pinia store
  that no longer exist in this codebase (superseded by `packages/api` /
  `packages/utils`) — these tests were already dead/broken before this branch and
  are unrelated to this fix.

## Test plan

- [x] `tsc --noEmit --skipLibCheck` clean on `packages/utils` and `packages/api`
      (pre-existing unrelated errors in third-party `.d.ts` files and one unrelated
      test-mock type error confirmed unrelated to the changed files).
- [x] Confirmed via AD4M executor source that `'local'`-status links are excluded
      from the link language's sync path, so the signing round-trip cannot leak to
      peers even when `perspectiveUuid` is an already-shared neighbourhood.
- [x] Manual verification: create a new community via Flux embedded in WE — confirm
      no transient `<name>-meta` sidebar entry appears.
- [x] Manual verification (if the "Initialize Flux Community on an existing shared
      WE space" flow is live): with a second peer joined to that neighbourhood,
      confirm no stray meta links appear on their side during community
      initialization.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved community/neighbourhood publishing so meta links are generated using the correct perspective, making published links more consistent.
  * Reduced unnecessary temporary steps during meta-link creation, which should make the process more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->