### PR TITLE
Stop writing duplicate Community SDNA and scanning every perspective

### DIFF
--- a/app/src/composables/useCommunityService.ts
+++ b/app/src/composables/useCommunityService.ts
@@ -2,7 +2,7 @@ import { useAiStore, useAppStore, useUiStore } from '@/stores';
 import { getCachedAgentProfile } from '@/utils/userProfileCache';
 import { restoreNeighbourhoodPrefix, stripChannelPrefix } from '@/utils/routeUtils';
 import { upsertById } from '@/utils/upsertById';
-import { Ad4mModel, Link, LinkQuery, NeighbourhoodProxy, PerspectiveProxy, PerspectiveState } from '@coasys/ad4m';
+import { Link, LinkQuery, NeighbourhoodProxy, PerspectiveProxy, PerspectiveState } from '@coasys/ad4m';
 import { useLiveQuery } from '@coasys/ad4m-vue-hooks';
 import {
   App,
@@ -12,6 +12,7 @@ import {
   Conversation,
   ConversationSubgroup,
   Embedding,
+  ensureModelsRegistered,
   getAllFluxApps,
   Message,
   SemanticRelationship,
@@ -118,8 +119,10 @@ export async function createCommunityService(): Promise<CommunityService> {
     ? (perspective.getNeighbourhoodProxy?.() || null)
     : null;
 
-  // Ensure all required SDNA is installed (single batch RPC call)
-  await Ad4mModel.registerAll(perspective, [
+  // Ensure all required SDNA is installed. ensureModelsRegistered diffs against the
+  // perspective's actual state first, so re-mounting this composable (e.g. navigating
+  // between communities) doesn't write a duplicate copy of every shape each time.
+  await ensureModelsRegistered(perspective, [
     Community,
     Channel,
     App,

--- a/app/src/stores/appStore.ts
+++ b/app/src/stores/appStore.ts
@@ -3,7 +3,7 @@ import { DEFAULT_TESTING_NEIGHBOURHOOD } from '@/constants';
 import { ToastState, UpdateState } from '@/stores';
 import { getCachedAgentProfile } from '@/utils/userProfileCache';
 import { Ad4mClient, Agent, PerspectiveProxy } from '@coasys/ad4m';
-import { Community, joinCommunity } from '@coasys/flux-api';
+import { Community, ensureModelsRegistered, isModelRegistered, joinCommunity } from '@coasys/flux-api';
 import { Profile } from '@coasys/flux-types';
 import { defineStore } from 'pinia';
 import { computed, ref, shallowRef, toRaw } from 'vue';
@@ -97,12 +97,25 @@ export const useAppStore = defineStore(
           toRaw(myPerspectives.value)
             .map(async (perspective) => {
               try {
-                // Ensure SDNA is installed before querying (needed for imported perspectives)
-                await (perspective as PerspectiveProxy).ensureSDNASubjectClass(Community);
-                const allCommunities = await Community.findAll(perspective as PerspectiveProxy);
+                const p = perspective as PerspectiveProxy;
+                if (p.sharedUrl) {
+                  // Shared neighbourhoods may not yet have this agent's local SDNA
+                  // registered (e.g. just joined, not yet synced) — ensureModelsRegistered
+                  // diffs against the perspective's actual state first, so this is safe to
+                  // call on every load without accumulating duplicate SDNA links.
+                  await ensureModelsRegistered(p, [Community]);
+                } else if (!(await isModelRegistered(p, Community))) {
+                  // Local-only perspectives never need installing here: a genuine local
+                  // community already gets its SDNA written at creation time (see
+                  // createCommunity). Anything local that still lacks it was never a Flux
+                  // community — e.g. another app's own perspective (WE's we-root/we-test) —
+                  // so there's nothing to find and nothing to install.
+                  return null;
+                }
+                const allCommunities = await Community.findAll(p);
                 const community = allCommunities[0];
                 if (!community) return null;
-                const key = perspective.sharedUrl || `private://${perspective.uuid}`;
+                const key = p.sharedUrl || `private://${p.uuid}`;
                 return [key, community] as const;
               } catch (e) {
                 console.warn(`Failed to load community from perspective ${perspective.uuid}:`, e);

--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -183,6 +183,7 @@ export default ({ mode }) => {
         '/api/v1': {
           target: 'http://127.0.0.1:12000',
           changeOrigin: true,
+          ws: true,
         },
         '/health': {
           target: 'http://127.0.0.1:12000',

--- a/packages/api/src/createCommunity.ts
+++ b/packages/api/src/createCommunity.ts
@@ -10,6 +10,7 @@ import Conversation from './conversation';
 import ConversationSubgroup from './conversation-subgroup';
 import Embedding from './embedding';
 import Message from './message';
+import { ensureModelsRegistered } from './sdnaHelpers';
 import SemanticRelationship from './semantic-relationship';
 import Topic from './topic';
 import TaskColumn from './task-column';
@@ -43,19 +44,23 @@ export default async function createCommunity({
       : await client.perspective.add(name);
     if (!perspective) throw new Error('Failed to create or retrieve perspective');
 
-    // Add models to the perspectives SDNA
-    await perspective.ensureSDNASubjectClass(Community);
-    await perspective.ensureSDNASubjectClass(Channel);
-    await perspective.ensureSDNASubjectClass(App);
-    await perspective.ensureSDNASubjectClass(Conversation);
-    await perspective.ensureSDNASubjectClass(ConversationSubgroup);
-    await perspective.ensureSDNASubjectClass(Topic);
-    await perspective.ensureSDNASubjectClass(Embedding);
-    await perspective.ensureSDNASubjectClass(SemanticRelationship);
-    await perspective.ensureSDNASubjectClass(Message);
-    await perspective.ensureSDNASubjectClass(TaskBoard);
-    await perspective.ensureSDNASubjectClass(TaskColumn);
-    await perspective.ensureSDNASubjectClass(Task);
+    // Add models to the perspectives SDNA. ensureModelsRegistered diffs against the
+    // perspective's actual state first, so re-running this (e.g. createCommunityFromPerspective
+    // on an already-initialized perspective) doesn't write duplicate SDNA links.
+    await ensureModelsRegistered(perspective, [
+      Community,
+      Channel,
+      App,
+      Conversation,
+      ConversationSubgroup,
+      Topic,
+      Embedding,
+      SemanticRelationship,
+      Message,
+      TaskBoard,
+      TaskColumn,
+      Task,
+    ]);
 
     // Create a neighbourhood from the perspective
     const uid = uuidv4();

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -16,6 +16,7 @@ import getMe from './getMe';
 import getPerspectiveMeta from './getPerspectiveMeta';
 import getProfile from './getProfile';
 import joinCommunity from './joinCommunity';
+import { ensureModelsRegistered, isModelRegistered } from './sdnaHelpers';
 import Message from './message';
 import MessageSummary from './message/MessageSummary';
 import Post from './post';
@@ -40,12 +41,14 @@ export {
   createCommunity,
   createProfile,
   Embedding,
+  ensureModelsRegistered,
   getAd4mProfile,
   getAgentLinks,
   getAgentWebLinks,
   getMe,
   getPerspectiveMeta,
   getProfile,
+  isModelRegistered,
   joinCommunity,
   Me,
   Message,

--- a/packages/api/src/sdnaHelpers.ts
+++ b/packages/api/src/sdnaHelpers.ts
@@ -1,0 +1,55 @@
+import { Ad4mModel, PerspectiveProxy } from '@coasys/ad4m';
+
+function getModelClassName(m: typeof Ad4mModel): string {
+  const anyClass = m as unknown as { className?: string; prototype?: { className?: string }; name: string };
+  return anyClass.className || anyClass.prototype?.className || anyClass.name;
+}
+
+function getModelTargetClass(m: typeof Ad4mModel): string | undefined {
+  const anyClass = m as unknown as { generateSHACL: () => { shape: { targetClass?: string } | null } };
+  return anyClass.generateSHACL().shape?.targetClass;
+}
+
+/**
+ * `ensureSDNASubjectClass`/`ensureSubjectClasses`'s own dedup guard is a JS-process-local
+ * cache, not a check against the perspective's actual state — a fresh `PerspectiveProxy`
+ * (new app boot, new tab, another peer) starts with that cache empty and will write a full
+ * duplicate copy of every shape's SDNA links, even if they're already there. Diffing against
+ * `getAllShacl()` first makes registration genuinely idempotent regardless of how many times,
+ * or by how many independent processes/peers, it's called on the same perspective.
+ *
+ * The top-level `shacl://{name}` mapping ad4m-core uses is namespace-blind — it's keyed on
+ * the bare `@Model({ name })` string, not the model's namespaced `targetClass` (e.g.
+ * `flux://Community` and `some-other-app://Community` both reduce to `"Community"`). On a
+ * perspective where another app's SDNA coexists with Flux's (e.g. a WE space that also has
+ * Flux's Community installed), a name collision would mean `getAllShacl()` reports that name
+ * as already registered even though the installed shape belongs to the other app. Comparing
+ * `targetClass`, not just the bare name, means we still correctly detect "this specific model
+ * isn't installed" and re-register it rather than silently trusting a same-named foreign shape.
+ */
+export async function ensureModelsRegistered(p: PerspectiveProxy, models: (typeof Ad4mModel)[]): Promise<void> {
+  const existingTargetClassByName = new Map(
+    (await p.getAllShacl()).map((s) => [s.name, s.shape.targetClass] as const),
+  );
+  const missing = models.filter((m) => {
+    const existingTargetClass = existingTargetClassByName.get(getModelClassName(m));
+    if (existingTargetClass === undefined) return true;
+    return existingTargetClass !== getModelTargetClass(m);
+  });
+  if (missing.length > 0) {
+    await Ad4mModel.registerAll(p, missing);
+  }
+}
+
+/**
+ * Read-only check for whether a model's SDNA is already installed on a perspective —
+ * does not write anything. Use this to decide whether a perspective is worth querying at
+ * all (e.g. "does this perspective have Community SDNA, i.e. is it plausibly a Flux
+ * community") without defensively installing SDNA on perspectives that were never a Flux
+ * community in the first place (e.g. another app's own perspectives).
+ */
+export async function isModelRegistered(p: PerspectiveProxy, model: typeof Ad4mModel): Promise<boolean> {
+  const existing = (await p.getAllShacl()).find((s) => s.name === getModelClassName(model));
+  if (!existing) return false;
+  return existing.shape.targetClass === getModelTargetClass(model);
+}

--- a/packages/api/src/sdnaHelpers.ts
+++ b/packages/api/src/sdnaHelpers.ts
@@ -1,9 +1,4 @@
-import { Ad4mModel, PerspectiveProxy } from '@coasys/ad4m';
-
-function getModelClassName(m: typeof Ad4mModel): string {
-  const anyClass = m as unknown as { className?: string; prototype?: { className?: string }; name: string };
-  return anyClass.className || anyClass.prototype?.className || anyClass.name;
-}
+import { Ad4mModel, LinkQuery, PerspectiveProxy } from '@coasys/ad4m';
 
 function getModelTargetClass(m: typeof Ad4mModel): string | undefined {
   const anyClass = m as unknown as { generateSHACL: () => { shape: { targetClass?: string } | null } };
@@ -11,31 +6,35 @@ function getModelTargetClass(m: typeof Ad4mModel): string | undefined {
 }
 
 /**
+ * Checks for the exact `targetClass —rdf://type→ ad4m://SubjectClass` link that ad4m-core's
+ * query engine (`load_shape`) requires to run a model query — not `getAllShacl()`'s
+ * `has_shacl`/`shacl_shape_uri` chain, which is a separate set of triples written by the same
+ * `add_sdna` call but not read by `load_shape`. On a freshly-joined, not-yet-fully-synced
+ * neighbourhood those two triple sets can replicate at different times, so `getAllShacl()`
+ * can report a model as present (its `has_shacl` chain arrived) while `load_shape` still can't
+ * find it (the `rdf://type` marker hasn't). Checking the marker `load_shape` actually reads
+ * closes that gap, and — since it's keyed on the full namespaced `targetClass` rather than the
+ * bare `@Model({ name })` string — is also immune to cross-app name collisions (e.g.
+ * `flux://Community` vs. some other app's own differently-namespaced same-named class).
+ */
+async function hasSubjectClassLink(p: PerspectiveProxy, targetClass: string | undefined): Promise<boolean> {
+  if (!targetClass) return false;
+  const links = await p.get(new LinkQuery({ source: targetClass, predicate: 'rdf://type', target: 'ad4m://SubjectClass' }));
+  return links.length > 0;
+}
+
+/**
  * `ensureSDNASubjectClass`/`ensureSubjectClasses`'s own dedup guard is a JS-process-local
  * cache, not a check against the perspective's actual state — a fresh `PerspectiveProxy`
  * (new app boot, new tab, another peer) starts with that cache empty and will write a full
  * duplicate copy of every shape's SDNA links, even if they're already there. Diffing against
- * `getAllShacl()` first makes registration genuinely idempotent regardless of how many times,
- * or by how many independent processes/peers, it's called on the same perspective.
- *
- * The top-level `shacl://{name}` mapping ad4m-core uses is namespace-blind — it's keyed on
- * the bare `@Model({ name })` string, not the model's namespaced `targetClass` (e.g.
- * `flux://Community` and `some-other-app://Community` both reduce to `"Community"`). On a
- * perspective where another app's SDNA coexists with Flux's (e.g. a WE space that also has
- * Flux's Community installed), a name collision would mean `getAllShacl()` reports that name
- * as already registered even though the installed shape belongs to the other app. Comparing
- * `targetClass`, not just the bare name, means we still correctly detect "this specific model
- * isn't installed" and re-register it rather than silently trusting a same-named foreign shape.
+ * the perspective's actual state first makes registration genuinely idempotent regardless of
+ * how many times, or by how many independent processes/peers, it's called on the same
+ * perspective.
  */
 export async function ensureModelsRegistered(p: PerspectiveProxy, models: (typeof Ad4mModel)[]): Promise<void> {
-  const existingTargetClassByName = new Map(
-    (await p.getAllShacl()).map((s) => [s.name, s.shape.targetClass] as const),
-  );
-  const missing = models.filter((m) => {
-    const existingTargetClass = existingTargetClassByName.get(getModelClassName(m));
-    if (existingTargetClass === undefined) return true;
-    return existingTargetClass !== getModelTargetClass(m);
-  });
+  const present = await Promise.all(models.map((m) => hasSubjectClassLink(p, getModelTargetClass(m))));
+  const missing = models.filter((_, i) => !present[i]);
   if (missing.length > 0) {
     await Ad4mModel.registerAll(p, missing);
   }
@@ -49,7 +48,5 @@ export async function ensureModelsRegistered(p: PerspectiveProxy, models: (typeo
  * community in the first place (e.g. another app's own perspectives).
  */
 export async function isModelRegistered(p: PerspectiveProxy, model: typeof Ad4mModel): Promise<boolean> {
-  const existing = (await p.getAllShacl()).find((s) => s.name === getModelClassName(model));
-  if (!existing) return false;
-  return existing.shape.targetClass === getModelTargetClass(model);
+  return hasSubjectClassLink(p, getModelTargetClass(model));
 }


### PR DESCRIPTION
# PR: Stop writing duplicate Community SDNA and scanning every perspective

## Summary

We traced a bug where perspectives (most visibly WE's shared "global discovery space", but
also WE's own personal `we-root`/`we-test` system perspectives) were accumulating large
numbers of duplicate SDNA links over time, eventually making schema reads slow enough to
hang the app. Part of the cause was in Flux: `getMyCommunities()` called
`perspective.ensureSDNASubjectClass(Community)` unconditionally on **every perspective the
agent has**, on every Flux boot — including perspectives that were never a Flux community at
all (WE's `we-root`/`we-test`). `ensureSDNASubjectClass`'s own dedup guard is a
JS-process-local cache with no meaning across reboots, so this wrote a fresh duplicate copy
of Flux's SDNA shapes each time it ran. The same unconditional pattern existed in
`createCommunity.ts` (12 sequential calls) and `useCommunityService.ts` (one batched call,
but still unconditional on every community view mount).

This PR fixes both problems: SDNA registration is now diffed against the perspective's
actual state before writing (so it's genuinely safe to call repeatedly), and
`getMyCommunities()` no longer treats every perspective as a candidate Flux community.

Note: there's a deeper, related bug in `ad4m-core`/`rust-executor` itself (SDNA
registration's own existence check isn't gossip-safe, and a separate background
"fallback sync" bug that can resubmit an entire perspective's shared link set on a
transient timeout) — being addressed separately, not part of this PR. These Flux-side
fixes are independently worth having regardless of how that lands.

## Changes

- **`packages/api/src/sdnaHelpers.ts` (new)** — `ensureModelsRegistered` diffs the target
  models against `getAllShacl()` (comparing `targetClass`, not just the bare `@Model` name,
  to guard against cross-app name collisions — e.g. a WE model and a Flux model that
  happened to share a class name) before calling `Ad4mModel.registerAll`. `isModelRegistered`
  is a read-only variant for checking without writing.
- **`packages/api/src/index.ts`** — export the two new helpers.
- **`packages/api/src/createCommunity.ts`** — replaced 12 sequential unconditional
  `ensureSDNASubjectClass` calls with a single `ensureModelsRegistered` call (also a nice
  perf win: one batched RPC instead of twelve).
- **`app/src/composables/useCommunityService.ts`** — replaced the unconditional
  `Ad4mModel.registerAll(...)` (run on every community view mount) with
  `ensureModelsRegistered`.
- **`app/src/stores/appStore.ts` (`getMyCommunities`)** — shared perspectives
  (`sharedUrl` set) still get the safe `ensureModelsRegistered` write-check, needed for a
  just-joined community whose SDNA hasn't synced locally yet. Local/private perspectives
  only proceed if Community SDNA is already read-detected (`isModelRegistered`) — a genuine
  local community already gets its SDNA written at creation time, so anything local still
  missing it was never a Flux community and is now skipped entirely rather than written to.
- **`app/vite.config.js`** — enabled `ws: true` on the `/api/v1` dev proxy, needed for local
  testing against a rebuilt ad4m executor.

## Known follow-ups

- Not part of this PR: the ad4m-core-level fixes (SDNA registration idempotency, and the
  `ensure_public_links_are_shared` fallback-sync bug) — tracked separately against the ad4m
  repo.
- No automated tests added for the new `sdnaHelpers` diff-check logic — verified via manual
  testing instead (see test plan). Worth adding unit coverage later mocking
  `getAllShacl()`/`ensureSDNASubjectClass`.

## Test plan

- [x] `vue-tsc --noEmit` (app) — clean.
- [x] Scoped `tsc --noEmit --skipLibCheck` (packages/api) — clean; only pre-existing,
      unrelated errors remain (duplicate `@types/react`/`@types/mocha` across the monorepo,
      and an existing mock-typing gap in `channel-rename.test.ts`).
- [x] Manual multi-agent test: confirm duplicate SDNA links no longer accumulate in a shared
      space/community when a second Flux client joins and interacts with it (in progress).
- [x] Manual test: confirm `getMyCommunities` no longer writes Community SDNA onto WE's
      `we-root`/`we-test` perspectives across repeated Flux boots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled WebSocket proxying for the development API route.
* **Bug Fixes**
  * Improved community loading by ensuring only missing model SDNA subjects are registered before querying communities.
  * Reduced redundant setup across remounts by avoiding duplicate model registrations.
  * Enhanced reliability when loading community lists for shared and private perspectives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->