### PR TITLE
chore: bump @coasys/ad4m and @coasys/ad4m-connect to shacl-perf-fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
       "@coasys/flux-utils": "workspace:*",
       "@coasys/flux-vue": "workspace:*",
       "@coasys/flux-webrtc": "workspace:*",
-      "@coasys/ad4m": "0.13.0-test-8-profile-cache-fix",
-      "@coasys/ad4m-connect": "0.13.0-guest-connect-2",
+      "@coasys/ad4m": "0.13.0-test-8-shacl-perf-fix",
+      "@coasys/ad4m-connect": "0.13.0-test-8-shacl-perf-fix",
       "@coasys/ad4m-vue-hooks": "0.13.0-test-8",
       "@coasys/ad4m-react-hooks": "0.13.0-test-8"
     }


### PR DESCRIPTION
Points at the new published versions carrying the getShacl/getAllShacl read-path parallelization + dedup fix (ad4m PR: fix/shacl-read-path-dedup). Netlify's build-with-ad4m-link.sh always builds ad4m from source and overrides these at build time regardless of what's pinned here, so this is purely for accuracy in plain local installs that don't use that script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated bundled dependency versions to newer test builds for improved stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->